### PR TITLE
require case insensitive comparison for the /= test

### DIFF
--- a/anagram/anagram_test.hs
+++ b/anagram/anagram_test.hs
@@ -35,4 +35,6 @@ anagramTests =
     anagramsFor "Orchestra" ["cashregister", "Carthorse", "radishes"]
   , testCase "does not detect a word as its own anagram" $
     [] @=? anagramsFor "banana" ["banana"]
+  , testCase "does not detect a word as its own anagram (case insensitive)" $
+    [] @=? anagramsFor "Banana" ["baNana"]
   ]

--- a/anagram/example.hs
+++ b/anagram/example.hs
@@ -1,12 +1,10 @@
 module Anagram (anagramsFor) where
-import Data.Char (toLower)
 import Data.List (sort)
+import Data.Char (toLower)
 
 anagramsFor :: String -> [String] -> [String]
-anagramsFor word = filter isDifferent
+anagramsFor word = filter (isAnagram . normalize)
   where
-    la = map toLower word
-    sa = sort la
-    isDifferent b = la /= lb && sa == sb
-      where lb = map toLower b
-            sb = sort lb
+    normalize xs = let nxs = map toLower xs in (nxs, sort nxs)
+    (nw, sw) = normalize word
+    isAnagram (w, s) = nw /= w && sw == s


### PR DESCRIPTION
This adds a test that requires the "word is not its own anagram" test to be done case insensitively, just like the rest of the exercise. Tired of suggesting this improvement for every submission :)
