### PR TITLE
Fix never-failing test in list_ops exercise

### DIFF
--- a/list-ops/list-ops_test.hs
+++ b/list-ops/list-ops_test.hs
@@ -60,9 +60,9 @@ listOpsTests =
   , testCase "++ of large lists" $ do
     [1 .. big] @=? [1 .. big `div` 2] L.++ [1 + big `div` 2 .. big]
   , testCase "concat of no lists" $ do
-    [] @=? concat ([] :: [[Int]])
+    [] @=? L.concat ([] :: [[Int]])
   , testCase "concat of list of lists" $ do
-    [1 .. 6] @=? concat [[1, 2], [3], [], [4, 5, 6 :: Int]]
+    [1 .. 6] @=? L.concat [[1, 2], [3], [], [4, 5, 6 :: Int]]
   , testCase "concat of large list of small lists" $ do
-    [1 .. big] @=? concat (map (:[]) [1 .. big])
+    [1 .. big] @=? L.concat (map (:[]) [1 .. big])
   ]


### PR DESCRIPTION
I noticed when completing this exercise that all the tests passed even while my implementation of `concat` was `undefined`... looking at the test it looks like the `L` prefix was missed off the function calls in this test.
