### PR TITLE
New test case for robot-name: resetting a robot should affect only one robot

### DIFF
--- a/robot-name/robot-name_test.hs
+++ b/robot-name/robot-name_test.hs
@@ -67,6 +67,7 @@ robotTests =
     n1' <- robotName r1
     n2' <- robotName r2
     n1' /= n2' @? "names should be different"
+    n2 @=? n2'
   ]
 
 matchesPattern :: String -> Bool


### PR DESCRIPTION
Thanks to [etrepum](https://github.com/etrepum#readme).
In an earlier version of my solution, `resetName` changed the name of all robots making their names equal.
