### PR TITLE
Add phone-number test (input too long)

### DIFF
--- a/phone-number/phone-number_test.hs
+++ b/phone-number/phone-number_test.hs
@@ -28,6 +28,8 @@ numberTests =
     "0000000000" @=? number "21234567890"
   , testCase "invalid when 9 digits" $
     "0000000000" @=? number "123456789"
+  , testCase "invalid when 12 digits" $
+    "0000000000" @=? number "123456789012"
   , testCase "invalid when empty" $
     "0000000000" @=? number ""
   , testCase "invalid when no digits present" $


### PR DESCRIPTION
No tests checked for inputs longer than 11 digits. A correct solution should be 10 or 11 digits.

The following solution passed with before this change. The new test detects the error.

``` haskell
module Phone (areaCode, number, prettyPrint) where

import Data.Char (isDigit)

number :: String -> String
number = cleanup . digits
  where
    digits = filter isDigit
    cleanup n = case compare (length n) 10 of
      EQ -> n
      GT | head n == '1' -> tail n
      _ -> replicate 10 '0'

areaCode :: String -> String
areaCode = take 3 . number


prettyPrint :: String -> String
prettyPrint n = "(" ++ areaCode n ++ ") "
                ++ prefix cleaned ++ "-"
                ++ suffix cleaned
  where
    cleaned = number n
    prefix = take 3 . drop 3
    suffix = take 4 . drop 6
```

Before:

```
Cases: 12  Tried: 12  Errors: 0  Failures: 0
```

After

```
### Failure in: 0:5:invalid when 12 digits 
expected: "0000000000"
 but got: "23456789012"
Cases: 13  Tried: 13  Errors: 0  Failures: 1
```
