### PR TITLE
Rename the base file.

### DIFF
--- a/list-ops/ListOps_StartHere.hs
+++ b/list-ops/ListOps_StartHere.hs
@@ -1,3 +1,6 @@
+-- Copy this file to `ListOps.hs` and use it as a starting point for the
+-- exercise.
+
 module ListOps
   ( length
   , reverse


### PR DESCRIPTION
This exercise contains a file that the user is supposed to use as a starting
point.  It seems that naming this file the same as the file the user submits
to exercism (the site) interferes with exercism's (the tool) ability to
download the user's submitted file.  In other words, naming it the same breaks
the `exercism r` command.

Hopefully the new name of the file, together with a comment in the file about
copying it, is enough instruction.

Signed-off-by: Magnus Therning magnus@therning.org
