### PR TITLE
Added test to check for single valid queen

### DIFF
--- a/queen-attack/queen-attack_test.hs
+++ b/queen-attack/queen-attack_test.hs
@@ -37,6 +37,7 @@ board = concat [ "_ _ _ _ _ _ _ _\n"
 queenTests :: [Test]
 queenTests =
   [ testCase "empty board" $ emptyBoard @=? boardString Nothing Nothing
+  , testCase "one queen" $ emptyBoard @=? boardString (Just (1,5)) Nothing
   , testCase "board" $ board @=? boardString (Just (2, 4)) (Just (6, 6))
   , testCase "attacks" $ do
     False @=? canAttack (2, 3) (4, 7)


### PR DESCRIPTION
Added test to ensure that the `boardString` function (in the solution) must return an empty board if one of the arguments (i.e., one of the queens) is `Nothing`.
