### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 bin/configlet
 bin/configlet.exe
 
-# exercism/xhaskell specific patterns
+# exercism/haskell specific patterns
 *.cabal
 
 # sorted default .gitignore from github/gitignore/Haskell.gitignore

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xHaskell
+# Exercism Haskell Track
 
-[![Build Status](https://travis-ci.org/exercism/xhaskell.png?branch=master)](https://travis-ci.org/exercism/xhaskell)
+[![Build Status](https://travis-ci.org/exercism/haskell.png?branch=master)](https://travis-ci.org/exercism/haskell)
 
 Exercism exercises in Haskell
 
@@ -43,7 +43,7 @@ problem description.
 - If you already have a fix for it you may [write a pull request](#writing-a-pull-request).
 
 #### Reviewing issues and pull requests
-If you have a dedicated opinion you are welcome to [write a comment](https://help.github.com/articles/commenting-on-a-pull-request/) for an [issue](https://github.com/exercism/xhaskell/issues) or a [pull request](https://github.com/exercism/xhaskell/pulls).
+If you have a dedicated opinion you are welcome to [write a comment](https://help.github.com/articles/commenting-on-a-pull-request/) for an [issue](https://github.com/exercism/haskell/issues) or a [pull request](https://github.com/exercism/haskell/pulls).
 Please be detailed and include reasons, links or arguments to support your opinion.
 
 #### Porting exercises
@@ -107,10 +107,10 @@ format that has all dependencies and build instructions for an exercise.
 - `test/Tests.hs` is the [test suite](#test-suite).
 
 ### Writing an issue
-To report a bug you should [create an issue](https://help.github.com/articles/creating-an-issue/) [here](https://github.com/exercism/xhaskell/issues).
+To report a bug you should [create an issue](https://help.github.com/articles/creating-an-issue/) [here](https://github.com/exercism/haskell/issues).
 
 ### Writing a pull request
-To fix a bug you should [create a pull request from a fork](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) [here](https://github.com/exercism/xhaskell/pulls). See also [here](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#git-basics) for more information.
+To fix a bug you should [create a pull request from a fork](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) [here](https://github.com/exercism/haskell/pulls). See also [here](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#git-basics) for more information.
 
 ### Development Dependencies
 You should have [Stack](http://docs.haskellstack.org/) installed in your system to make contributing to this repository easier.

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "haskell",
   "language": "Haskell",
-  "repository": "https://github.com/exercism/xhaskell",
+  "repository": "https://github.com/exercism/haskell",
   "active": true,
   "exercises": [
     {

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -45,7 +45,7 @@ stack ghci
 
 ## Feedback, Issues, Pull Requests
 
-The [exercism/xhaskell](https://github.com/exercism/xhaskell) repository on
+The [exercism/haskell](https://github.com/exercism/haskell) repository on
 GitHub is the home for all of the Haskell exercises.
 
 If you have feedback about an exercise, or want to help implementing a new


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1