### PR TITLE
spiral-matrix: Add exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -346,6 +346,12 @@
       ]
     },
     {
+      "slug": "spiral-matrix",
+      "difficulty": 5,
+      "topics": [
+      ]
+    },
+    {
       "slug": "custom-set",
       "difficulty": 5,
       "topics": [

--- a/exercises/spiral-matrix/examples/success-standard/package.yaml
+++ b/exercises/spiral-matrix/examples/success-standard/package.yaml
@@ -1,0 +1,16 @@
+name: spiral-matrix
+
+dependencies:
+  - base
+
+library:
+  exposed-modules: Spiral
+  source-dirs: src
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - spiral-matrix
+      - hspec

--- a/exercises/spiral-matrix/examples/success-standard/src/Spiral.hs
+++ b/exercises/spiral-matrix/examples/success-standard/src/Spiral.hs
@@ -1,0 +1,17 @@
+module Spiral (spiral) where
+
+-- | Create a square matrix of natural numbers in a inward, clockwise spiral.
+spiral :: Int -> [[Int]]
+spiral l = matrix (spiralIndex (l, l)) (l, l)
+  where
+    -- If an index isn't in the first row of a matrix, it is in the
+    -- 90 degress-rotated, complementary matrix.
+    spiralIndex :: Integral a => (a, a) -> (a, a) -> a
+    spiralIndex     _  (1, j) = j
+    spiralIndex (h, w) (i, j) = w + spiralIndex (w, h - 1) (w - j + 1, i - 1)
+
+-- Build a lazy, list-based matrix based on a formula.
+matrix :: ((Int, Int) -> a) -> (Int, Int) -> [[a]]
+matrix f (rows, columns) = [[ f (i, j)
+                            | j <- [1..columns] ]
+                            | i <- [1..rows   ] ]

--- a/exercises/spiral-matrix/package.yaml
+++ b/exercises/spiral-matrix/package.yaml
@@ -1,0 +1,20 @@
+name: spiral-matrix
+version: 1.0.0.1
+
+dependencies:
+  - base
+
+library:
+  exposed-modules: Spiral
+  source-dirs: src
+  dependencies:
+  # - foo       # List here the packages you
+  # - bar       # want to use in your solution.
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - spiral-matrix
+      - hspec

--- a/exercises/spiral-matrix/src/Spiral.hs
+++ b/exercises/spiral-matrix/src/Spiral.hs
@@ -1,0 +1,4 @@
+module Spiral (spiral) where
+
+spiral :: Int -> [[Int]]
+spiral size = error "You need to implement this function."

--- a/exercises/spiral-matrix/stack.yaml
+++ b/exercises/spiral-matrix/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-8.2

--- a/exercises/spiral-matrix/test/Tests.hs
+++ b/exercises/spiral-matrix/test/Tests.hs
@@ -1,0 +1,40 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
+import Spiral (spiral)
+
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
+main :: IO ()
+main = hspecWith defaultConfig {configFastFail = True} specs
+
+specs :: Spec
+specs = describe "spiral" $ do
+
+  it "empty spiral" $
+    spiral 0 `shouldBe` []
+
+  it "trivial spiral" $
+    spiral 1 `shouldBe` [ [1] ]
+
+  it "spiral of side length 2" $
+    spiral 2 `shouldBe` [ [1, 2]
+                        , [4, 3] ]
+
+  it "spiral of side length 3" $
+    spiral 3 `shouldBe` [ [1, 2, 3]
+                        , [8, 9, 4]
+                        , [7, 6, 5] ]
+
+  it "spiral of side length 4" $
+    spiral 4 `shouldBe` [ [ 1,  2,  3, 4]
+                        , [12, 13, 14, 5]
+                        , [11, 16, 15, 6]
+                        , [10,  9,  8, 7] ]
+
+  it "spiral of side length 5" $
+    spiral 5 `shouldBe` [ [ 1,  2,  3,  4, 5]
+                        , [16, 17, 18, 19, 6]
+                        , [15, 24, 25, 20, 7]
+                        , [14, 23, 22, 21, 8]
+                        , [13, 12, 11, 10, 9] ]


### PR DESCRIPTION
This is the implementation of the exercise as initially proposed in exercism/x-common#840.

I'm not sure about the difficulty, so I inserted it just after `food-chain`, for contrast.

~~We shouldn't merge this before `x-common`, as this exercises references the `1.0.0` version of the test cases. I'm just opening this PR so that we can have fix major problems beforehand.~~