### PR TITLE
fix pangram test for duplicate mixed-case chars

### DIFF
--- a/exercises/pangram/package.yaml
+++ b/exercises/pangram/package.yaml
@@ -1,5 +1,5 @@
 name: pangram
-version: 1.0.0.3
+version: 1.1.0.3
 
 dependencies:
   - base

--- a/exercises/pangram/package.yaml
+++ b/exercises/pangram/package.yaml
@@ -1,5 +1,5 @@
 name: pangram
-version: 1.0.0.2
+version: 1.0.0.3
 
 dependencies:
   - base

--- a/exercises/pangram/test/Tests.hs
+++ b/exercises/pangram/test/Tests.hs
@@ -53,7 +53,7 @@ cases = [ Case { description = "sentence empty"
                , expected    = True
                }
         , Case { description = "upper and lower case versions of the same character should not be counted separately"
-               , input       = "the quick brown fox jumped over the lazy FOX"
+               , input       = "the quick brown fox jumps over with lazy FX"
                , expected    = False
                }
         ]


### PR DESCRIPTION
From what I can see, the last test case is inteded to catch incorrect
programs such as this, which don't take into account different-cased
duplicates:

```haskell
isPangram = (== 26) . length . nub . filter isAlpha
```

However the above program passed the final test as the count of distinct
upper and lower case characters is 27, rather than 26.

This commit changes the test text to a non-pangram that has exactly 26
distinct upper and lower case characters, which causes the above,
incorrect program to fail.