### PR TITLE
simple-linked-list: Make library import explicit

### DIFF
--- a/exercises/simple-linked-list/test/Tests.hs
+++ b/exercises/simple-linked-list/test/Tests.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
-import Test.QuickCheck   (property)
-import Test.QuickCheck.Arbitrary
+import Test.Hspec                (Spec, it, shouldBe)
+import Test.Hspec.Runner         (configFastFail, defaultConfig, hspecWith)
+import Test.QuickCheck           (property)
+import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
 
 import LinkedList
   ( datum


### PR DESCRIPTION
This exercise has the only test suite in the repository that does an unqualified import of a module from an external library without an explicit import list.

This style of importing in not recommended:
  - https://wiki.haskell.org/Import_modules_properly

Besides that, it is nice to keep consistency when it is cheap to do it.