### PR TITLE
travis: Disable building the benchmarks

### DIFF
--- a/bin/test-example
+++ b/bin/test-example
@@ -50,9 +50,13 @@ runstack () {
     stack "$@" ${SET_RESOLVER}     `# Select the correct resolver. `\
                --install-ghc       `# Download GHC if not in cache.`\
                --no-terminal       `# Terminal detection is broken.`\
-               --bench             `# Build benchmarks, but        `\
-               --no-run-benchmarks `# do not run them.             `\
-               --pedantic          `# Enable -Wall and -Werror.    `
+               --pedantic          `# Enable -Wall and -Werror.    `\
+             # --bench             `# Build benchmarks, but        `\
+             # --no-run-benchmarks `# do not run them.             `
+             #
+             # We are temporarily disabling the benchmarks
+             # to speed up Travis-CI and try to stay below
+             # the 50 minutes limit.
 }
 
 if [ "$exampletype" = "success" ]; then

--- a/bin/test-stub
+++ b/bin/test-stub
@@ -50,5 +50,9 @@ else
     echo "building stub with everything else"
     stack build ${SET_RESOLVER} --install-ghc --no-terminal \
                 --test  --no-run-tests                      \
-                --bench --no-run-benchmarks
+              # --bench --no-run-benchmarks
+              #
+              # We are temporarily disabling the benchmarks
+              # to speed up Travis-CI and try to stay below
+              # the 50 minutes limit.
 fi


### PR DESCRIPTION
Travis timeouts jobs after 50 minutes, and we are having problems trying to stay under this limit when building initially with an empty cache.

To save some precious minutes, we are temporarily disabling compilation of the benchmarks suites, because 'criterion' is a really heavy dependency.

Related to #568.