### PR TITLE
Call configlet subcommand on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
  - |
     set -e
 
-    configlet .               # Check basic track configuration.
+    configlet lint .          # Check basic track configuration.
     hlint ${TRAVIS_BUILD_DIR} # Run `hlint` on the entire repository.
 
     # Explicit set exercises' resolver only if it's not the current one.


### PR DESCRIPTION
This changes configlet to pass a subcommand.

For now, we've released a version of configlet which handles both the old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the subcommand before we
release the version of configlet that requires the subcommand.


https://github.com/exercism/configlet/pull/23