### PR TITLE
Remove redundant key/value pairs from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,5 @@
 {
-  "slug": "haskell",
   "language": "Haskell",
-  "repository": "https://github.com/exercism/haskell",
   "active": true,
   "exercises": [
     {
@@ -11,6 +9,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+
       ]
     },
     {
@@ -20,6 +19,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+
       ]
     },
     {
@@ -29,6 +29,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+
       ]
     },
     {
@@ -38,6 +39,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+
       ]
     },
     {
@@ -47,6 +49,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+
       ]
     },
     {
@@ -56,6 +59,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+
       ]
     },
     {
@@ -75,6 +79,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+
       ]
     },
     {
@@ -84,6 +89,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+
       ]
     },
     {
@@ -103,6 +109,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
+
       ]
     },
     {
@@ -142,6 +149,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
+
       ]
     },
     {
@@ -151,6 +159,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
+
       ]
     },
     {
@@ -202,6 +211,7 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
+
       ]
     },
     {
@@ -211,6 +221,7 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
+
       ]
     },
     {
@@ -220,6 +231,7 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
+
       ]
     },
     {
@@ -239,6 +251,7 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
+
       ]
     },
     {
@@ -248,6 +261,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+
       ]
     },
     {
@@ -279,6 +293,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+
       ]
     },
     {
@@ -298,6 +313,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+
       ]
     },
     {
@@ -307,6 +323,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+
       ]
     },
     {
@@ -367,6 +384,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+
       ]
     },
     {
@@ -376,6 +394,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+
       ]
     },
     {
@@ -385,6 +404,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+
       ]
     },
     {
@@ -394,6 +414,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+
       ]
     },
     {
@@ -403,6 +424,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+
       ]
     },
     {
@@ -412,6 +434,7 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
+
       ]
     },
     {
@@ -431,6 +454,7 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
+
       ]
     },
     {
@@ -450,6 +474,7 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
+
       ]
     },
     {
@@ -470,6 +495,7 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
+
       ]
     },
     {
@@ -489,6 +515,7 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
+
       ]
     },
     {
@@ -508,6 +535,7 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
+
       ]
     },
     {
@@ -528,6 +556,7 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
+
       ]
     },
     {
@@ -549,6 +578,7 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
+
       ]
     },
     {
@@ -570,6 +600,7 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
+
       ]
     },
     {
@@ -602,6 +633,7 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
+
       ]
     },
     {
@@ -625,6 +657,7 @@
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
+
       ]
     },
     {
@@ -634,6 +667,7 @@
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
+
       ]
     },
     {
@@ -723,6 +757,7 @@
       "unlocked_by": null,
       "difficulty": 9,
       "topics": [
+
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -9,7 +9,6 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-
       ]
     },
     {
@@ -19,7 +18,6 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-
       ]
     },
     {
@@ -29,7 +27,6 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-
       ]
     },
     {
@@ -39,7 +36,6 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-
       ]
     },
     {
@@ -49,7 +45,6 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-
       ]
     },
     {
@@ -59,7 +54,6 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-
       ]
     },
     {
@@ -79,7 +73,6 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-
       ]
     },
     {
@@ -89,7 +82,6 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-
       ]
     },
     {
@@ -109,7 +101,6 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-
       ]
     },
     {
@@ -149,7 +140,6 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-
       ]
     },
     {
@@ -159,7 +149,6 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-
       ]
     },
     {
@@ -211,7 +200,6 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-
       ]
     },
     {
@@ -221,7 +209,6 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-
       ]
     },
     {
@@ -231,7 +218,6 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-
       ]
     },
     {
@@ -251,7 +237,6 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-
       ]
     },
     {
@@ -261,7 +246,6 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-
       ]
     },
     {
@@ -293,7 +277,6 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-
       ]
     },
     {
@@ -313,7 +296,6 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-
       ]
     },
     {
@@ -323,7 +305,6 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-
       ]
     },
     {
@@ -384,7 +365,6 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-
       ]
     },
     {
@@ -394,7 +374,6 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-
       ]
     },
     {
@@ -404,7 +383,6 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-
       ]
     },
     {
@@ -414,7 +392,6 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-
       ]
     },
     {
@@ -424,7 +401,6 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-
       ]
     },
     {
@@ -434,7 +410,6 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
-
       ]
     },
     {
@@ -454,7 +429,6 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
-
       ]
     },
     {
@@ -474,7 +448,6 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
-
       ]
     },
     {
@@ -495,7 +468,6 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
-
       ]
     },
     {
@@ -515,7 +487,6 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
-
       ]
     },
     {
@@ -535,7 +506,6 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
-
       ]
     },
     {
@@ -556,7 +526,6 @@
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
-
       ]
     },
     {
@@ -578,7 +547,6 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
-
       ]
     },
     {
@@ -600,7 +568,6 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
-
       ]
     },
     {
@@ -633,7 +600,6 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
-
       ]
     },
     {
@@ -657,7 +623,6 @@
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
-
       ]
     },
     {
@@ -667,7 +632,6 @@
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
-
       ]
     },
     {
@@ -757,7 +721,6 @@
       "unlocked_by": null,
       "difficulty": 9,
       "topics": [
-
       ]
     },
     {


### PR DESCRIPTION
The slug is not used anywhere. We initialize a track based on knowing the Track ID.
Since the repository is always named after the track ID, this field, too, is redundant,
as it can be inferred.


See https://github.com/exercism/meta/issues/19