### PR TITLE
maintainers: Set etrepum as alumnus

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -3,7 +3,7 @@
     {
       "github_username": "etrepum",
       "show_on_website": false,
-      "alumnus": false,
+      "alumnus": true,
       "name": null,
       "bio": null,
       "link_text": null,


### PR DESCRIPTION
As suggested in #581.

@petertseng wrote:

> Probably makes sense to say that etrepum is alumnus.

@kytrinyx wrote:

Probably. If he doesn't pop in here I'll send him an email to see if he's OK with that.