### PR TITLE
maintainers: Show rbasso on website

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -32,10 +32,10 @@
     },
     {
       "github_username": "rbasso",
-      "show_on_website": false,
+      "show_on_website": true,
       "alumnus": false,
       "name": null,
-      "bio": null,
+      "bio": "In a world plagued by mutability, where side-effects scorch the land, a hobbyist programmer joins a fellowship of coders to save The Source.",
       "link_text": null,
       "link_url": null,
       "avatar_url": null


### PR DESCRIPTION
Without a `bio`, only my GitHub username would be displayed, so I wrote a Haskell-specific *"[In a world...](http://tvtropes.org/pmwiki/pmwiki.php/Main/InAWorld)"* one, inspired by [this trailer](https://www.youtube.com/watch?v=fVDzuT0fXro).