### PR TITLE
Add an explicit example pattern to the track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,8 @@
 {
   "language": "Haskell",
   "active": true,
+  "solution_pattern": "example.*[.]hs",
+  "ignore_pattern": "example",
   "exercises": [
     {
       "uuid": "c97d9dda-c7ee-4595-b447-693559d03ba5",


### PR DESCRIPTION
The default example pattern matches more than just the reference solution.
It also matches some of the support files that live within the example directories, such
as yaml files.

This has been tested against configlet to ensure that it detects a reference solution
for each exercise.