### PR TITLE
leap: Improve test suite to cover corner case.

### DIFF
--- a/exercises/leap/package.yaml
+++ b/exercises/leap/package.yaml
@@ -1,5 +1,5 @@
 name: leap
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/leap/test/Tests.hs
+++ b/exercises/leap/test/Tests.hs
@@ -30,7 +30,7 @@ cases = [ Case { description = "year not divisible by 4: common year"
                , expected    = False
                }
         , Case { description = "year divisible by 4, not divisible by 100: leap year"
-               , input       = 2016
+               , input       = 2020
                , expected    = True
                }
         , Case { description = "year divisible by 100, not divisible by 400: common year"


### PR DESCRIPTION
Currently, the test suite has a loophole where it is possible to pass
all the tests with a function that simply checks if year \`mod\` 16 == 0.

This commit changes one of the test cases so that is no longer possible.