### PR TITLE
config.json: add "Define type" to complex-number

### DIFF
--- a/config.json
+++ b/config.json
@@ -130,6 +130,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
+        "Define type"
       ]
     },
     {


### PR DESCRIPTION
Compare:

    ruby -rjson -e 'puts JSON.parse(File.read("config.json"))["exercises"].select { |e| e["topics"]&.include?("Define type") }.map { |e| e["slug"] }' | sort

    git grep Dummy