### PR TITLE
alphametics, wordy: Use $> instead of *> pure

### DIFF
--- a/exercises/alphametics/examples/success-standard/src/Alphametics.hs
+++ b/exercises/alphametics/examples/success-standard/src/Alphametics.hs
@@ -2,6 +2,7 @@
 module Alphametics (solve) where
 
 import Control.Monad (guard)
+import Data.Functor (($>))
 import Data.List (foldl', find, union)
 import Data.Maybe (fromJust, isJust, listToMaybe)
 import Prelude hiding (Word)
@@ -109,7 +110,7 @@ word :: Parser (Term Integer)
 word = Word <$> many1 upper
 
 plus :: Parser (Term Integer -> Term Integer -> Term Integer)
-plus = trimmed (char '+') *> pure Plus
+plus = trimmed (char '+') $> Plus
 
 trimmed :: Parser a -> Parser a
 trimmed p = spaces *> p <* spaces

--- a/exercises/wordy/examples/success-standard/src/WordProblem.hs
+++ b/exercises/wordy/examples/success-standard/src/WordProblem.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module WordProblem (answer) where
+import Data.Functor (($>))
 import Data.Text (pack)
 import Data.List (foldl')
 import Control.Applicative ((<|>))
@@ -10,7 +11,7 @@ answerParser :: Parser Int
 answerParser = do
   n <- "What is " *> signed decimal
   ops <- many' (space *> operation)
-  "?" *> pure (foldl' (flip ($)) n ops)
+  "?" $> foldl' (flip ($)) n ops
 
 answer :: String -> Maybe Int
 answer = maybeResult . parse answerParser . pack
@@ -19,7 +20,7 @@ operation :: Parser (Int -> Int)
 operation = (flip <$> operator) <* space <*> signed decimal
 
 operator :: Parser (Int -> Int -> Int)
-operator = "plus"          *> pure (+) <|>
-           "minus"         *> pure (-) <|>
-           "multiplied by" *> pure (*) <|>
-           "divided by"    *> pure div
+operator = "plus"          $> (+) <|>
+           "minus"         $> (-) <|>
+           "multiplied by" $> (*) <|>
+           "divided by"    $> div


### PR DESCRIPTION
This is suggested by a newer version of hlint, so Travis CI had pointed
this out for the builds that use nightly Stackage.

2.0.9 is known not to emit the suggestion in question, and 2.0.10 is
known to do so.