### PR TITLE
forth 1.3.0.5: rm test of empty input

### DIFF
--- a/exercises/forth/package.yaml
+++ b/exercises/forth/package.yaml
@@ -1,5 +1,5 @@
 name: forth
-version: 1.2.0.4
+version: 1.3.0.5
 
 dependencies:
   - base

--- a/exercises/forth/test/Tests.hs
+++ b/exercises/forth/test/Tests.hs
@@ -14,10 +14,7 @@ specs = do
 
     let runTexts = fmap toList . foldM (flip evalText) empty
 
-    describe "parsing and numbers" $ do
-      it "empty input results in empty stack" $
-        toList empty `shouldBe` []
-
+    describe "parsing and numbers" $
       it "numbers just get pushed onto the stack" $
         runTexts ["1 2 3 4 5"] `shouldBe` Right [1, 2, 3, 4, 5]
 


### PR DESCRIPTION
https://github.com/exercism/problem-specifications/pull/976

It is not necessary to verify that the implementation matches the
specification, since the specification does not define behaviour of
empty inputs.