### PR TITLE
Implementing protein-translation

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,6 +14,16 @@
       ]
     },
     {
+      "uuid": "f750e380-fe16-42c0-8b3d-8acd7e443a6e",
+      "slug": "protein-translation",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "Maybe"
+      ]
+    },
+    {
       "uuid": "0ad7d756-1cbd-44f4-a64f-0dc7e9eb40f4",
       "slug": "leap",
       "core": false,

--- a/config.json
+++ b/config.json
@@ -23,16 +23,6 @@
       ]
     },
     {
-      "uuid": "f750e380-fe16-42c0-8b3d-8acd7e443a6e",
-      "slug": "protein-translation",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "Maybe"
-      ]
-    },
-    {
       "uuid": "6cbb7841-9d96-4528-88e3-6e98a450fd7c",
       "slug": "space-age",
       "core": false,
@@ -322,6 +312,16 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
+      ]
+    },
+    {
+      "uuid": "f750e380-fe16-42c0-8b3d-8acd7e443a6e",
+      "slug": "protein-translation",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "Maybe"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -14,6 +14,15 @@
       ]
     },
     {
+      "uuid": "0ad7d756-1cbd-44f4-a64f-0dc7e9eb40f4",
+      "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+      ]
+    },
+    {
       "uuid": "f750e380-fe16-42c0-8b3d-8acd7e443a6e",
       "slug": "protein-translation",
       "core": false,
@@ -21,15 +30,6 @@
       "difficulty": 1,
       "topics": [
         "Maybe"
-      ]
-    },
-    {
-      "uuid": "0ad7d756-1cbd-44f4-a64f-0dc7e9eb40f4",
-      "slug": "leap",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
       ]
     },
     {

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -1,0 +1,3 @@
+```Haskell
+f = error "regenerate me!""
+```

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -1,3 +1,102 @@
-```Haskell
-f = error "regenerate me!""
+# Protein Translation
+
+Translate RNA sequences into proteins.
+
+RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+
+RNA: `"AUGUUUUCU"` => translates to
+
+Codons: `"AUG", "UUU", "UCU"`
+=> which become a polypeptide with the following sequence =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.  If it works for one codon, the program should work for all of them.
+However, feel free to expand the list in the test suite to include them all.
+
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+
+All subsequent codons after are ignored, like this:
+
+RNA: `"AUGUUUUCUUAAAUG"` =>
+
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
+
+Below are the codons and resulting Amino Acids needed for the exercise.
+
+Codon                 | Protein
+:---                  | :---
+AUG                   | Methionine
+UUU, UUC              | Phenylalanine
+UUA, UUG              | Leucine
+UCU, UCC, UCA, UCG    | Serine
+UAU, UAC              | Tyrosine
+UGU, UGC              | Cysteine
+UGG                   | Tryptophan
+UAA, UAG, UGA         | STOP
+
+Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki/Translation_(biology))
+
+
+## Getting Started
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/haskell).
+
+## Running the tests
+
+To run the test suite, execute the following command:
+
+```bash
+stack test
 ```
+
+#### If you get an error message like this...
+
+```
+No .cabal file found in directory
+```
+
+You are probably running an old stack version and need
+to upgrade it.
+
+#### Otherwise, if you get an error message like this...
+
+```
+No compiler found, expected minor version match with...
+Try running "stack setup" to install the correct GHC...
+```
+
+Just do as it says and it will download and install
+the correct compiler version:
+
+```bash
+stack setup
+```
+
+## Running *GHCi*
+
+If you want to play with your solution in GHCi, just run the command:
+
+```bash
+stack ghci
+```
+
+## Feedback, Issues, Pull Requests
+
+The [exercism/haskell](https://github.com/exercism/haskell) repository on
+GitHub is the home for all of the Haskell exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue.  We'll do our best to help you!
+
+## Source
+
+Tyler Long
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/protein-translation/examples/success-standard/package.yaml
+++ b/exercises/protein-translation/examples/success-standard/package.yaml
@@ -1,0 +1,16 @@
+name: protein-translation
+
+dependencies:
+  - base
+
+library:
+  exposed-modules: ProteinTranslation
+  source-dirs: src
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - protein-translation
+      - hspec

--- a/exercises/protein-translation/examples/success-standard/package.yaml
+++ b/exercises/protein-translation/examples/success-standard/package.yaml
@@ -6,6 +6,7 @@ dependencies:
 library:
   exposed-modules: ProteinTranslation
   source-dirs: src
+  dependencies: split
 
 tests:
   test:

--- a/exercises/protein-translation/examples/success-standard/src/ProteinTranslation.hs
+++ b/exercises/protein-translation/examples/success-standard/src/ProteinTranslation.hs
@@ -1,0 +1,26 @@
+module ProteinTranslation(proteins) where
+
+separate :: [a] -> [[a]]
+separate [] = []
+separate xs = take 3 xs : separate (drop 3 xs)
+
+validCodon :: String -> Bool
+validCodon x = x `elem` ["AUG","UUU","UUC","UUA","UUG","UCU","UCC","UCA","UCG",
+                         "UAU","UAC","UGU","UGC","UGG","UAA","UAG","UGA"]
+
+proteins' :: String -> String
+proteins' x | x == "AUG"                         = "Methionine"
+            | x == "UGG"                         = "Tryptophan"
+            | x `elem` ["UUU","UUC"]             = "Phenylalanine"
+            | x `elem` ["UUA","UUG"]             = "Leucine"
+            | x `elem` ["UCU","UCC","UCA","UCG"] = "Serine"
+            | x `elem` ["UAU","UAC"]             = "Tyrosine"
+            | x `elem` ["UGU","UGC"]             = "Cysteine"
+            | otherwise                          = "STOP"
+
+proteins :: String -> Maybe [String]
+proteins xs = if length xs `mod` 3 == 0 && all validCodon codons
+                then  Just (takeWhile (/= "STOP") (map proteins' codons))
+                else Nothing
+  where
+    codons = separate xs

--- a/exercises/protein-translation/examples/success-standard/src/ProteinTranslation.hs
+++ b/exercises/protein-translation/examples/success-standard/src/ProteinTranslation.hs
@@ -1,8 +1,6 @@
 module ProteinTranslation(proteins) where
 
-separate :: [a] -> [[a]]
-separate [] = []
-separate xs = take 3 xs : separate (drop 3 xs)
+import Data.List.Split (chunksOf)
 
 validCodon :: String -> Bool
 validCodon x = x `elem` ["AUG","UUU","UUC","UUA","UUG","UCU","UCC","UCA","UCG",
@@ -20,7 +18,7 @@ proteins' x | x == "AUG"                         = "Methionine"
 
 proteins :: String -> Maybe [String]
 proteins xs = if length xs `mod` 3 == 0 && all validCodon codons
-                then  Just (takeWhile (/= "STOP") (map proteins' codons))
+                then Just (takeWhile (/= "STOP") (map proteins' codons))
                 else Nothing
   where
-    codons = separate xs
+    codons = chunksOf 3 xs

--- a/exercises/protein-translation/package.yaml
+++ b/exercises/protein-translation/package.yaml
@@ -1,0 +1,20 @@
+name: protein-translation
+version: 1.1.0.1
+
+dependencies:
+  - base
+
+library:
+  exposed-modules: ProteinTranslation
+  source-dirs: src
+  dependencies:
+  # - foo       # List here the packages you
+  # - bar       # want to use in your solution.
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - protein-translation
+      - hspec

--- a/exercises/protein-translation/package.yaml
+++ b/exercises/protein-translation/package.yaml
@@ -1,5 +1,5 @@
 name: protein-translation
-version: 1.1.0.1
+version: 1.0.1.1
 
 dependencies:
   - base

--- a/exercises/protein-translation/package.yaml
+++ b/exercises/protein-translation/package.yaml
@@ -1,5 +1,5 @@
 name: protein-translation
-version: 1.0.1.1
+version: 1.1.0.1
 
 dependencies:
   - base

--- a/exercises/protein-translation/src/ProteinTranslation.hs
+++ b/exercises/protein-translation/src/ProteinTranslation.hs
@@ -1,0 +1,4 @@
+module PerfectNumbers(proteins) where
+
+proteins :: String -> Maybe [String]
+proteins = error "You need to implement this function!"

--- a/exercises/protein-translation/src/ProteinTranslation.hs
+++ b/exercises/protein-translation/src/ProteinTranslation.hs
@@ -1,4 +1,4 @@
-module PerfectNumbers(proteins) where
+module ProteinTranslation(proteins) where
 
 proteins :: String -> Maybe [String]
 proteins = error "You need to implement this function!"

--- a/exercises/protein-translation/stack.yaml
+++ b/exercises/protein-translation/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-9.11

--- a/exercises/protein-translation/stack.yaml
+++ b/exercises/protein-translation/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-9.11
+resolver: lts-10.2

--- a/exercises/protein-translation/test/Tests.hs
+++ b/exercises/protein-translation/test/Tests.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE RecordWildCards #-}
+
+import Data.Foldable     (for_)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
+import ProteinTranslation (proteins)
+
+main :: IO ()
+main = hspecWith defaultConfig {configFastFail = True} specs
+
+specs :: Spec
+specs = describe "proteins" $ for_ cases test
+  where
+
+    test Case{..} = it description assertion
+      where
+        assertion = proteins input `shouldBe` expected
+
+
+data Case = Case { description :: String
+                 , input       :: String
+                 , expected    :: Maybe [String]
+                 }
+
+cases :: [Case]
+cases = [ Case { description = "Methionine RNA sequence"
+               , input       = "AUG"
+               , expected    = Just ["Methionine"]
+               }
+        , Case { description = "Phenylalanine RNA sequence 1"
+               , input       = "UUU"
+               , expected    = Just ["Phenylalanine"]
+               }
+        , Case { description = "Phenylalanine RNA sequence 2"
+               , input       = "UUC"
+               , expected    = Just ["Phenylalanine"]
+               }
+        , Case { description = "Leucine RNA sequence 1"
+               , input       = "UUA"
+               , expected    = Just ["Leucine"]
+               }
+        , Case { description = "Leucine RNA sequence 2"
+               , input       = "UUG"
+               , expected    = Just ["Leucine"]
+               }
+        , Case { description = "Serine RNA sequence 1"
+               , input       = "UCU"
+               , expected    = Just ["Serine"]
+               }
+        , Case { description = "Serine RNA sequence 2"
+               , input       = "UCC"
+               , expected    = Just ["Serine"]
+               }
+        , Case { description = "Serine RNA sequence 3"
+               , input       = "UCA"
+               , expected    = Just ["Serine"]
+               }
+        , Case { description = "Serine RNA sequence 4"
+               , input       = "UCG"
+               , expected    = Just ["Serine"]
+               }
+        , Case { description = "Tyrosine RNA sequence 1"
+               , input       = "UAU"
+               , expected    = Just ["Tyrosine"]
+               }
+        , Case { description = "Tyrosine RNA sequence 2"
+               , input       = "UAC"
+               , expected    = Just ["Tyrosine"]
+               }
+        , Case { description = "Cysteine RNA sequence 1"
+               , input       = "UGU"
+               , expected    = Just ["Cysteine"]
+               }
+        , Case { description = "Cysteine RNA sequence 2"
+               , input       = "UGC"
+               , expected    = Just ["Cysteine"]
+               }
+        , Case { description = "Tryptophan RNA sequence"
+               , input       = "UGG"
+               , expected    = Just ["Tryptophan"]
+               }
+        , Case { description = "STOP codon RNA sequence 1"
+               , input       = "UAA"
+               , expected    = Just []
+               }
+        , Case { description = "STOP codon RNA sequence 2"
+               , input       = "UAG"
+               , expected    = Just []
+               }
+        , Case { description = "STOP codon RNA sequence 3"
+               , input       = "UGA"
+               , expected    = Just []
+               }
+        , Case { description = "Translate RNA strand into correct protein list"
+               , input       = "AUGUUUUGG"
+               , expected    = Just ["Methionine","Phenylalanine","Tryptophan"]
+               }
+        , Case { description = "Translation stops if STOP codon at beginning of sequence"
+               , input       = "UAGUGG"
+               , expected    = Just []
+               }
+        , Case { description = "Translation stops if STOP codon at end of two-codon sequence"
+               , input       = "UGGUAG"
+               , expected    = Just ["Tryptophan"]
+               }
+        , Case { description = "Translation stops if STOP codon at end of three-codon sequence"
+               , input       = "AUGUUUUAA"
+               , expected    = Just ["Methionine","Phenylalanine"]
+               }
+        , Case { description = "Translation stops if STOP codon in middle of three-codon sequence"
+               , input       = "UGGUAGUGG"
+               , expected    = Just ["Tryptophan"]
+               }
+        , Case { description = "Translation stops if STOP codon in middle of six-codon sequence"
+               , input       = "UGGUGUUAUUAAUGGUUU"
+               , expected    = Just ["Tryptophan","Cysteine","Tyrosine"]
+               }
+        ]


### PR DESCRIPTION
I wanted to use  ```chunksOf``` from [Data.List.Split](https://hackage.haskell.org/package/split-0.2.3.2/docs/Data-List-Split.html#v:chunksOf) but apparently it is not in the cabal configuration