### PR TITLE
bob 1.1.0.4: Add yelling question rule

### DIFF
--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -6,6 +6,8 @@ Bob answers 'Sure.' if you ask him a question.
 
 He answers 'Whoa, chill out!' if you yell at him.
 
+He answers 'Calm down, I know what I'm doing!' if you yell a question at him.
+
 He says 'Fine. Be that way!' if you address him without actually saying
 anything.
 

--- a/exercises/bob/examples/success-standard/src/Bob.hs
+++ b/exercises/bob/examples/success-standard/src/Bob.hs
@@ -1,16 +1,20 @@
 module Bob (responseFor) where
 import Data.Char (isSpace, isUpper, isAlpha)
 
-data Prompt = Silence | Yell | Question | Other
+data Prompt = Silence | YellQuestion | Yell | Question | Other
 
 classify :: String -> Prompt
 classify s | all isSpace s = Silence
-           | any isAlpha s && all isUpper (filter isAlpha s) = Yell
-           | '?' == last (filter (not . isSpace) s) = Question
+           | yell && question = YellQuestion
+           | yell = Yell
+           | question = Question
            | otherwise = Other
+           where yell = any isAlpha s && all isUpper (filter isAlpha s)
+                 question = '?' == last (filter (not . isSpace) s)
 
 response :: Prompt -> String
 response Silence = "Fine. Be that way!"
+response YellQuestion = "Calm down, I know what I'm doing!"
 response Yell = "Whoa, chill out!"
 response Question = "Sure."
 response Other = "Whatever."

--- a/exercises/bob/package.yaml
+++ b/exercises/bob/package.yaml
@@ -1,5 +1,5 @@
 name: bob
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/bob/test/Tests.hs
+++ b/exercises/bob/test/Tests.hs
@@ -54,7 +54,7 @@ cases = [ Case { description = "stating something"
                }
         , Case { description = "forceful question"
                , input       = "WHAT THE HELL WERE YOU THINKING?"
-               , expected    = "Whoa, chill out!"
+               , expected    = "Calm down, I know what I'm doing!"
                }
         , Case { description = "shouting numbers"
                , input       = "1, 2, 3 GO!"


### PR DESCRIPTION
Closes https://github.com/exercism/problem-specifications/issues/943.

It was possible for a message directed to Bob to be both a question and
yelling, which meant it was unclear which rule should take effect.
Resolve ambiguity by simply adding a rule for that case.

https://github.com/exercism/problem-specifications/pull/1025