### PR TITLE
remove trailing whitespace

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,12 +1,12 @@
-## Learning Haskell 
+## Learning Haskell
 
 Haskell is a purely functional language, which is a paradigm fundamentally different than the more
 commonly taught [object oriented approach](https://en.wikipedia.org/wiki/Object-oriented_programming). Because of this,
 learning Haskell can feel different than simply picking up another language.
 
 Fortunately there are numerous resources which presume some programming knowledge to begin with, such
-as 
-  - the popular [Learn You a Haskell For Great Good!](http://learnyouahaskell.com/) 
+as
+  - the popular [Learn You a Haskell For Great Good!](http://learnyouahaskell.com/)
   - University of Glasgow's [Functional Programming in Haskell](https://www.futurelearn.com/courses/functional-programming-haskell) course
   - FP Complete's [School of Haskell](https://www.schoolofhaskell.com/)
   - and the [Happy Learn Haskell Tutorial](http://www.happylearnhaskelltutorial.com/).

--- a/exercises/food-chain/examples/success-standard/src/FoodChain.hs
+++ b/exercises/food-chain/examples/success-standard/src/FoodChain.hs
@@ -43,4 +43,4 @@ comment animal = case animal of
   Dog    -> "What a hog, to swallow a dog!"
   Goat   -> "Just opened her throat and swallowed a goat!"
   Cow    -> "I don't know how she swallowed a cow!"
-  Horse  -> "She's dead, of course!" 
+  Horse  -> "She's dead, of course!"

--- a/exercises/forth/examples/success-standard/src/Forth.hs
+++ b/exercises/forth/examples/success-standard/src/Forth.hs
@@ -17,10 +17,10 @@ import Control.Arrow (first)
 
 type Value = Int
 type FWord = Text
-data Term 
+data Term
      = StartDefinition
      | EndDefinition
-     | V Value 
+     | V Value
      | W FWord
      deriving (Show, Ord, Eq)
 

--- a/exercises/parallel-letter-frequency/examples/success-standard/src/Frequency.hs
+++ b/exercises/parallel-letter-frequency/examples/success-standard/src/Frequency.hs
@@ -11,7 +11,7 @@ import qualified Data.Text as T
 -- | Compute the frequency of letters in the text using the given number of
 --   parallel workers.
 frequency :: Int -> [Text] -> Map Char Int
-frequency workers texts = 
+frequency workers texts =
     let chunkSize = ceiling (length texts % workers)
         freqs = map countLetters texts `using` parListChunk chunkSize rdeepseq
     in Map.unionsWith (+) freqs

--- a/exercises/sgf-parsing/examples/success-standard/src/Sgf.hs
+++ b/exercises/sgf-parsing/examples/success-standard/src/Sgf.hs
@@ -38,7 +38,7 @@ prop :: Parser (Text, [Text])
 prop = (,) <$> (T.pack <$> many1 (satisfy isUpper)) <*> many1 val
 
 -- | Parse a value, complete with brackets.
--- 
+--
 -- This is a bit tricky as there are escape sequences to take into account.
 --
 -- We'll use a simple folder with one bit of state: whether the last

--- a/exercises/zipper/examples/success-standard/src/Zipper.hs
+++ b/exercises/zipper/examples/success-standard/src/Zipper.hs
@@ -16,7 +16,7 @@ module Zipper (
 ) where
 
 -- | A binary tree.
-data BinTree a = BT { 
+data BinTree a = BT {
     btValue :: a,                 -- ^ Value
     btLeft  :: Maybe (BinTree a), -- ^ Left child
     btRight :: Maybe (BinTree a)  -- ^ Right child
@@ -53,7 +53,7 @@ toTree (Z v l r zt) = go (BT v l r) zt
 
 -- | Get the value of the focus node.
 value :: Zipper a -> a
-value = zValue 
+value = zValue
 
 -- | Get the left child of the focus node, if any.
 left :: Zipper a -> Maybe (Zipper a)
@@ -81,4 +81,4 @@ setLeft t z = z { zLeft = t }
 
 -- | Replace a right child tree.
 setRight :: Maybe (BinTree a) -> Zipper a -> Zipper a
-setRight t z = z { zRight = t } 
+setRight t z = z { zRight = t }


### PR DESCRIPTION
Now `git grep '  *$'` only has some README files where the
problem-specifications files contain trailing whitespace. So this is
good.

TBD: Should this be checked via CI?