### PR TITLE
match problem-specifications versions

### DIFF
--- a/exercises/acronym/package.yaml
+++ b/exercises/acronym/package.yaml
@@ -1,5 +1,5 @@
 name: acronym
-version: 1.1.0.3
+version: 1.2.0.4
 
 dependencies:
   - base

--- a/exercises/all-your-base/package.yaml
+++ b/exercises/all-your-base/package.yaml
@@ -1,5 +1,5 @@
 name: all-your-base
-version: 2.0.0.5
+version: 2.1.0.6
 
 dependencies:
   - base

--- a/exercises/all-your-base/test/Tests.hs
+++ b/exercises/all-your-base/test/Tests.hs
@@ -102,19 +102,19 @@ cases = [ Case { description  = "single bit one to decimal"
                , outputBase   = 10
                , outputDigits = Just [4, 2]
                }
-        , Case { description  = "first base is one"
+        , Case { description  = "input base is one"
                , inputBase    = 1
                , inputDigits  = []
                , outputBase   = 10
                , outputDigits = Nothing
                }
-        , Case { description  = "first base is zero"
+        , Case { description  = "input base is zero"
                , inputBase    = 0
                , inputDigits  = []
                , outputBase   = 10
                , outputDigits = Nothing
                }
-        , Case { description  = "first base is negative"
+        , Case { description  = "input base is negative"
                , inputBase    = -2
                , inputDigits  = [1]
                , outputBase   = 10
@@ -132,19 +132,19 @@ cases = [ Case { description  = "single bit one to decimal"
                , outputBase   = 10
                , outputDigits = Nothing
                }
-        , Case { description  = "second base is one"
+        , Case { description  = "output base is one"
                , inputBase    = 2
                , inputDigits  = [1, 0, 1, 0, 1, 0]
                , outputBase   = 1
                , outputDigits = Nothing
                }
-        , Case { description  = "second base is zero"
+        , Case { description  = "output base is zero"
                , inputBase    = 10
                , inputDigits  = [7]
                , outputBase   = 0
                , outputDigits = Nothing
                }
-        , Case { description  = "second base is negative"
+        , Case { description  = "output base is negative"
                , inputBase    = 2
                , inputDigits  = [1]
                , outputBase   = -7

--- a/exercises/allergies/package.yaml
+++ b/exercises/allergies/package.yaml
@@ -1,5 +1,5 @@
 name: allergies
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/anagram/package.yaml
+++ b/exercises/anagram/package.yaml
@@ -1,5 +1,5 @@
 name: anagram
-version: 1.0.1.4
+version: 1.1.0.5
 
 dependencies:
   - base

--- a/exercises/atbash-cipher/package.yaml
+++ b/exercises/atbash-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: atbash-cipher
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/bob/package.yaml
+++ b/exercises/bob/package.yaml
@@ -1,5 +1,5 @@
 name: bob
-version: 1.1.0.4
+version: 1.2.0.5
 
 dependencies:
   - base

--- a/exercises/bracket-push/package.yaml
+++ b/exercises/bracket-push/package.yaml
@@ -1,5 +1,5 @@
 name: bracket-push
-version: 1.1.0.2
+version: 1.2.0.3
 
 dependencies:
   - base

--- a/exercises/change/package.yaml
+++ b/exercises/change/package.yaml
@@ -1,5 +1,5 @@
 name: change
-version: 1.1.0.4
+version: 1.2.0.5
 
 dependencies:
   - base

--- a/exercises/collatz-conjecture/package.yaml
+++ b/exercises/collatz-conjecture/package.yaml
@@ -1,5 +1,5 @@
 name: collatz-conjecture
-version: 1.1.1.1
+version: 1.2.0.2
 
 dependencies:
   - base

--- a/exercises/connect/package.yaml
+++ b/exercises/connect/package.yaml
@@ -1,5 +1,5 @@
 name: connect
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/crypto-square/package.yaml
+++ b/exercises/crypto-square/package.yaml
@@ -1,5 +1,5 @@
 name: crypto-square
-version: 3.1.0.4
+version: 3.2.0.5
 
 dependencies:
   - base

--- a/exercises/diamond/package.yaml
+++ b/exercises/diamond/package.yaml
@@ -1,5 +1,5 @@
 name: diamond
-version: 1.0.0.1
+version: 1.1.0.2
 
 dependencies:
   - base

--- a/exercises/difference-of-squares/package.yaml
+++ b/exercises/difference-of-squares/package.yaml
@@ -1,5 +1,5 @@
 name: difference-of-squares
-version: 1.1.0.4
+version: 1.2.0.5
 
 dependencies:
   - base

--- a/exercises/dominoes/package.yaml
+++ b/exercises/dominoes/package.yaml
@@ -1,5 +1,5 @@
 name: dominoes
-version: 2.0.0.5
+version: 2.1.0.6
 
 dependencies:
   - base

--- a/exercises/isbn-verifier/examples/success-standard/src/IsbnVerifier.hs
+++ b/exercises/isbn-verifier/examples/success-standard/src/IsbnVerifier.hs
@@ -1,6 +1,7 @@
 module IsbnVerifier (isbn) where
 
 isbn :: String -> Bool
+isbn "" = False
 isbn xs = length nums == 10 && g nums `mod` 11 == 0 && l <= 1
   where
     nums = let nxs = f xs in if last xs == 'X' then nxs++[(1,10)] else nxs

--- a/exercises/isbn-verifier/package.yaml
+++ b/exercises/isbn-verifier/package.yaml
@@ -1,5 +1,5 @@
 name: isbn-verifier
-version: 2.0.0.2
+version: 2.2.0.3
 
 dependencies:
   - base

--- a/exercises/isbn-verifier/test/Tests.hs
+++ b/exercises/isbn-verifier/test/Tests.hs
@@ -71,4 +71,8 @@ cases = [ Case { description = "valid isbn number"
                , input       = "3-598-21515-X"
                , expected    = False
                }
+        , Case { description = "empty isbn"
+               , input       = ""
+               , expected    = False
+               }
         ]

--- a/exercises/luhn/package.yaml
+++ b/exercises/luhn/package.yaml
@@ -1,5 +1,5 @@
 name: luhn
-version: 1.0.0.2
+version: 1.1.0.3
 
 dependencies:
   - base

--- a/exercises/luhn/test/Tests.hs
+++ b/exercises/luhn/test/Tests.hs
@@ -24,7 +24,7 @@ cases = [ Case { description = "single digit strings can not be valid"
                , input       = "1"
                , expected    = False
                }
-        , Case { description = "A single zero is invalid"
+        , Case { description = "a single zero is invalid"
                , input       = "0"
                , expected    = False
                }

--- a/exercises/meetup/package.yaml
+++ b/exercises/meetup/package.yaml
@@ -1,5 +1,5 @@
 name: meetup
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/rail-fence-cipher/package.yaml
+++ b/exercises/rail-fence-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: rail-fence-cipher
-version: 1.1.0.1
+version: 1.0.1.2
 
 dependencies:
   - base

--- a/exercises/rna-transcription/package.yaml
+++ b/exercises/rna-transcription/package.yaml
@@ -1,5 +1,5 @@
 name: rna-transcription
-version: 1.0.1.4
+version: 1.1.0.5
 
 dependencies:
   - base

--- a/exercises/rna-transcription/test/Tests.hs
+++ b/exercises/rna-transcription/test/Tests.hs
@@ -40,16 +40,4 @@ cases = [ Case { description = "RNA complement of cytosine is guanine"
                , dna         =      "ACGTGGTCTTAA"
                , expected    = Just "UGCACCAGAAUU"
                }
-        , Case { description = "correctly handles invalid input (RNA instead of DNA)"
-               , dna         = "U"
-               , expected    = Nothing
-               }
-        , Case { description = "correctly handles completely invalid DNA input"
-               , dna         = "XXX"
-               , expected    = Nothing
-               }
-        , Case { description = "correctly handles partially invalid DNA input"
-               , dna         = "ACGTXXXCTTAA"
-               , expected    = Nothing
-               }
         ]


### PR DESCRIPTION
Mostly no-ops

This script helps:

```ruby
require 'json'
pr = ARGV[0]

exercise = `pwd`.chomp.split(?/).last
ver = JSON.parse(File.read("../../../problem-specifications/exercises/#{exercise}/canonical-data.json"))['version']
haskell_ver = Integer(`grep version: package.yaml`.chomp[-1])

`sed -i'' -e "s/^version: .*/version: #{ver}.#{haskell_ver + 1}/" package.yaml`

m = "#{exercise}: #{ver}.#{haskell_ver + 1}: no-op declare compliance with #{ver}

input object

https://github.com/exercism/problem-specifications/pull/#{pr}"

`git commit --all -m '#{m}'`

puts m
```

Remaining to do: alphametics adds big test which I'll probably comment out for time? We'll see

list-ops just haven't gotten around to using the exact same tests

palindrome-products not using Maybe
