### PR TITLE
 phone-number 1.4.0.5: Add cases for area code/exchange start with 1 (and accompanying no-ops)

### DIFF
--- a/exercises/hello-world/package.yaml
+++ b/exercises/hello-world/package.yaml
@@ -1,5 +1,5 @@
 name: hello-world
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/largest-series-product/package.yaml
+++ b/exercises/largest-series-product/package.yaml
@@ -1,5 +1,5 @@
 name: largest-series-product
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/leap/package.yaml
+++ b/exercises/leap/package.yaml
@@ -1,5 +1,5 @@
 name: leap
-version: 1.2.0.5
+version: 1.3.0.6
 
 dependencies:
   - base

--- a/exercises/minesweeper/package.yaml
+++ b/exercises/minesweeper/package.yaml
@@ -1,5 +1,5 @@
 name: minesweeper
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/nth-prime/package.yaml
+++ b/exercises/nth-prime/package.yaml
@@ -1,5 +1,5 @@
 name: nth-prime
-version: 2.0.0.4
+version: 2.1.0.5
 
 dependencies:
   - base

--- a/exercises/nucleotide-count/package.yaml
+++ b/exercises/nucleotide-count/package.yaml
@@ -1,5 +1,5 @@
 name: nucleotide-count
-version: 1.2.0.4
+version: 1.3.0.5
 
 dependencies:
   - base

--- a/exercises/pascals-triangle/package.yaml
+++ b/exercises/pascals-triangle/package.yaml
@@ -1,5 +1,5 @@
 name: pascals-triangle
-version: 1.2.0.5
+version: 1.3.0.6
 
 dependencies:
   - base

--- a/exercises/perfect-numbers/package.yaml
+++ b/exercises/perfect-numbers/package.yaml
@@ -1,5 +1,5 @@
 name: perfect-numbers
-version: 1.0.1.1
+version: 1.1.0.2
 
 dependencies:
   - base

--- a/exercises/phone-number/package.yaml
+++ b/exercises/phone-number/package.yaml
@@ -1,5 +1,5 @@
 name: phone-number
-version: 1.2.0.4
+version: 1.4.0.5
 
 dependencies:
   - base

--- a/exercises/phone-number/test/Tests.hs
+++ b/exercises/phone-number/test/Tests.hs
@@ -61,12 +61,20 @@ cases =
            , input       = "123-@:!-7890"
            , expected    = Nothing
            }
-    , Case { description = "invalid if area code does not start with 2-9"
+    , Case { description = "invalid if area code starts with 0"
+           , input       = "(023) 456-7890"
+           , expected    = Nothing
+           }
+    , Case { description = "invalid if area code starts with 1"
            , input       = "(123) 456-7890"
            , expected    = Nothing
            }
-    , Case { description = "invalid if exchange code does not start with 2-9"
+    , Case { description = "invalid if exchange code starts with 0"
            , input       = "(223) 056-7890"
+           , expected    = Nothing
+           }
+    , Case { description = "invalid if exchange code starts with 1"
+           , input       = "(223) 156-7890"
            , expected    = Nothing
            }
     ]

--- a/exercises/pig-latin/package.yaml
+++ b/exercises/pig-latin/package.yaml
@@ -1,5 +1,5 @@
 name: pig-latin
-version: 1.1.0.4
+version: 1.2.0.5
 
 dependencies:
   - base

--- a/exercises/rna-transcription/package.yaml
+++ b/exercises/rna-transcription/package.yaml
@@ -1,5 +1,5 @@
 name: rna-transcription
-version: 1.1.0.5
+version: 1.2.0.6
 
 dependencies:
   - base

--- a/exercises/roman-numerals/package.yaml
+++ b/exercises/roman-numerals/package.yaml
@@ -1,5 +1,5 @@
 name: roman-numerals
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/rotational-cipher/package.yaml
+++ b/exercises/rotational-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: rotational-cipher
-version: 1.1.0.1
+version: 1.2.0.2
 
 dependencies:
   - base

--- a/exercises/saddle-points/package.yaml
+++ b/exercises/saddle-points/package.yaml
@@ -1,5 +1,5 @@
 name: saddle-points
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - array

--- a/exercises/scrabble-score/package.yaml
+++ b/exercises/scrabble-score/package.yaml
@@ -1,5 +1,5 @@
 name: scrabble-score
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/secret-handshake/package.yaml
+++ b/exercises/secret-handshake/package.yaml
@@ -1,5 +1,5 @@
 name: secret-handshake
-version: 1.1.0.4
+version: 1.2.0.5
 
 dependencies:
   - base

--- a/exercises/sieve/package.yaml
+++ b/exercises/sieve/package.yaml
@@ -1,5 +1,5 @@
 name: sieve
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/space-age/package.yaml
+++ b/exercises/space-age/package.yaml
@@ -1,5 +1,5 @@
 name: space-age
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/spiral-matrix/package.yaml
+++ b/exercises/spiral-matrix/package.yaml
@@ -1,5 +1,5 @@
 name: spiral-matrix
-version: 1.0.0.1
+version: 1.1.0.2
 
 dependencies:
   - base

--- a/exercises/sublist/package.yaml
+++ b/exercises/sublist/package.yaml
@@ -1,5 +1,5 @@
 name: sublist
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/twelve-days/package.yaml
+++ b/exercises/twelve-days/package.yaml
@@ -1,5 +1,5 @@
 name: twelve-days
-version: 1.0.0.1
+version: 1.1.0.2
 
 dependencies:
   - base

--- a/exercises/zebra-puzzle/package.yaml
+++ b/exercises/zebra-puzzle/package.yaml
@@ -1,5 +1,5 @@
 name: zebra-puzzle
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base


### PR DESCRIPTION
still using the same script

```ruby
require 'json'
pr = ARGV[0]

exercise = `pwd`.chomp.split(?/).last
ver = JSON.parse(File.read("../../../problem-specifications/exercises/#{exercise}/canonical-data.json"))['version']
haskell_ver = Integer(`grep version: package.yaml`.chomp[-1])

`sed -i'' -e "s/^version: .*/version: #{ver}.#{haskell_ver + 1}/" package.yaml`

m = "#{exercise}: #{ver}.#{haskell_ver + 1}: no-op declare compliance with #{ver}

input object

https://github.com/exercism/problem-specifications/pull/#{pr}"

`git commit --all -m '#{m}'`

puts m
```