### PR TITLE
rna-transcription: Add test case for invalid input

### DIFF
--- a/exercises/rna-transcription/package.yaml
+++ b/exercises/rna-transcription/package.yaml
@@ -1,5 +1,5 @@
 name: rna-transcription
-version: 1.2.0.6
+version: 1.2.0.7
 
 dependencies:
   - base

--- a/exercises/rna-transcription/test/Tests.hs
+++ b/exercises/rna-transcription/test/Tests.hs
@@ -40,4 +40,8 @@ cases = [ Case { description = "RNA complement of cytosine is guanine"
                , dna         =      "ACGTGGTCTTAA"
                , expected    = Just "UGCACCAGAAUU"
                }
+        , Case { description = "Invalid input"
+               , dna         = "FOOBAR"
+               , expected    = Nothing
+               }
         ]

--- a/exercises/rna-transcription/test/Tests.hs
+++ b/exercises/rna-transcription/test/Tests.hs
@@ -40,8 +40,16 @@ cases = [ Case { description = "RNA complement of cytosine is guanine"
                , dna         =      "ACGTGGTCTTAA"
                , expected    = Just "UGCACCAGAAUU"
                }
-        , Case { description = "Invalid input"
-               , dna         = "FOOBAR"
+        , Case { description = "correctly handles invalid input (RNA instead of DNA)"
+               , dna         = "U"
+               , expected    = Nothing
+               }
+        , Case { description = "correctly handles completely invalid DNA input"
+               , dna         = "XXX"
+               , expected    = Nothing
+               }
+        , Case { description = "correctly handles partially invalid DNA input"
+               , dna         = "ACGTXXXCTTAA"
                , expected    = Nothing
                }
         ]


### PR DESCRIPTION
The return type of `Maybe String` already anticipates error handling, but I've seen many solutions on exercism.io that would just throw an exception on invalid input. This test should point people in the right direction.