### PR TITLE
rna-transcription: provide more accurate source info

### DIFF
--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -73,7 +73,7 @@ one, head over there and create an issue.  We'll do our best to help you!
 
 ## Source
 
-Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+Hyperphysics [http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html](http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
This one I did manually (there were only two) but remember the procedures:

```
git format-patch $PREVIOUS_COMMIT -- exercises/*/description.md exercises/*/metadata.yml 
vim *.patch
git checkout -b readme $PREVIOUS_COMMIT
git am *.patch
git rebase -i $PREVIOUS_COMMIT
# change all to edit
# for each commit:
#  in each repo:
#   generate, use commit command
# git rebase --continue
```

`../configlet/bin/generate . && git cal --date="$(git --git-dir=../problem-specifications/.git show --format=%ai -s HEAD)" --author="$(git --git-dir=../problem-specifications/.git show --format='%an <%ae>' -s HEAD)" -m "$(git --git-dir=../problem-specifications/.git log --format=%B -n1 HEAD)"`

our READMEs now match dae85658c4676c275dff5adee2ed0de109a38a9f

---

rna-transcription: provide more accurate source info

Original source seemed to mention a simple replacement of T with U
rather than the transcription being performed.

https://github.com/exercism/problem-specifications/issues/1078
https://github.com/exercism/problem-specifications/pull/1134
