### PR TITLE
match problem-specifications versions 

### DIFF
--- a/exercises/acronym/package.yaml
+++ b/exercises/acronym/package.yaml
@@ -1,5 +1,5 @@
 name: acronym
-version: 1.2.0.4
+version: 1.3.0.5
 
 dependencies:
   - base

--- a/exercises/acronym/test/Tests.hs
+++ b/exercises/acronym/test/Tests.hs
@@ -39,15 +39,11 @@ cases = [ Case { description = "basic"
                , input       = "First In, First Out"
                , expected    = "FIFO"
                }
-        , Case { description = "all caps words"
-               , input       = "PHP: Hypertext Preprocessor"
-               , expected    = "PHP"
-               }
-        , Case { description = "non-acronym all caps word"
+        , Case { description = "all caps word"
                , input       = "GNU Image Manipulation Program"
                , expected    = "GIMP"
                }
-        , Case { description = "hyphenated"
+        , Case { description = "punctuation without whitespace"
                , input       = "Complementary metal-oxide semiconductor"
                , expected    = "CMOS"
                }

--- a/exercises/anagram/package.yaml
+++ b/exercises/anagram/package.yaml
@@ -1,5 +1,5 @@
 name: anagram
-version: 1.1.0.5
+version: 1.2.0.6
 
 dependencies:
   - base

--- a/exercises/anagram/test/Tests.hs
+++ b/exercises/anagram/test/Tests.hs
@@ -35,16 +35,6 @@ cases = [ Case { description = "no matches"
                , candidates  = [ "hello", "world", "zombies", "pants"]
                , expected    = []
                }
-        , Case { description = "detects simple anagram"
-               , subject     = "ant"
-               , candidates  = ["tan", "stand", "at"]
-               , expected    = ["tan"]
-               }
-        , Case { description = "does not detect false positives"
-               , subject     = "galea"
-               , candidates  = ["eagle"]
-               , expected    = []
-               }
         , Case { description = "detects two anagrams"
                , subject     = "master"
                , candidates  = ["stream", "pigeon", "maters"]
@@ -65,11 +55,6 @@ cases = [ Case { description = "no matches"
                , candidates  = ["gallery", "ballerina", "regally", "clergy", "largely", "leading"]
                , expected    = ["gallery", "regally", "largely"]
                }
-        , Case { description = "does not detect identical words"
-               , subject     = "corn"
-               , candidates  = ["corn", "dark", "Corn", "rank", "CORN", "cron", "park"]
-               , expected    = ["cron"]
-               }
         , Case { description = "does not detect non-anagrams with identical checksum"
                , subject     = "mass"
                , candidates  = ["last"]
@@ -89,11 +74,6 @@ cases = [ Case { description = "no matches"
                , subject     = "orchestra"
                , candidates  = ["cashregister", "Carthorse", "radishes"]
                , expected    = ["Carthorse"]
-               }
-        , Case { description = "does not detect a word as its own anagram"
-               , subject     = "banana"
-               , candidates  = ["Banana"]
-               , expected    = []
                }
         , Case { description = "does not detect a anagram if the original word is repeated"
                , subject     = "go"

--- a/exercises/clock/package.yaml
+++ b/exercises/clock/package.yaml
@@ -1,5 +1,5 @@
 name: clock
-version: 1.0.1.3
+version: 2.2.1.4
 
 dependencies:
   - base

--- a/exercises/clock/test/Tests.hs
+++ b/exercises/clock/test/Tests.hs
@@ -29,6 +29,7 @@ specs = do
 
       describe "create" $ for_ createCases createTest
       describe "add"    $ for_ addCases    addTest
+      describe "sub"    $ for_ subCases    subTest
       describe "equal"  $ for_ equalCases  equalTest
 
   where
@@ -40,6 +41,10 @@ specs = do
     addTest (l, h, m, m', e) = it l assertion
       where
         assertion = toString (fromHourMin h m + m') `shouldBe` e
+
+    subTest (l, h, m, m', e) = it l assertion
+      where
+        assertion = toString (fromHourMin h m - m') `shouldBe` e
 
     equalTest (l, (h1, m1), (h2, m2), e) = it l assertion
       where
@@ -74,15 +79,17 @@ specs = do
       , ("add more than two hours with carry"            ,  0, 45,   160, "03:25")
       , ("add across midnight"                           , 23, 59,     2, "00:01")
       , ("add more than one day (1500 min = 25 hrs)"     ,  5, 32,  1500, "06:32")
-      , ("add more than two days"                        ,  1,  1,  3500, "11:21")
-      , ("subtract minutes"                              , 10,  3,    -3, "10:00")
-      , ("subtract to previous hour"                     , 10,  3,   -30, "09:33")
-      , ("subtract more than an hour"                    , 10,  3,   -70, "08:53")
-      , ("subtract across midnight"                      ,  0,  3,    -4, "23:59")
-      , ("subtract more than two hours"                  ,  0,  0,  -160, "21:20")
-      , ("subtract more than two hours with borrow"      ,  6, 15,  -160, "03:35")
-      , ("subtract more than one day (1500 min = 25 hrs)",  5, 32, -1500, "04:32")
-      , ("subtract more than two days"                   ,  2, 20, -3000, "00:20") ]
+      , ("add more than two days"                        ,  1,  1,  3500, "11:21") ]
+
+    subCases =
+      [ ("subtract minutes"                              , 10,  3,     3, "10:00")
+      , ("subtract to previous hour"                     , 10,  3,    30, "09:33")
+      , ("subtract more than an hour"                    , 10,  3,    70, "08:53")
+      , ("subtract across midnight"                      ,  0,  3,     4, "23:59")
+      , ("subtract more than two hours"                  ,  0,  0,   160, "21:20")
+      , ("subtract more than two hours with borrow"      ,  6, 15,   160, "03:35")
+      , ("subtract more than one day (1500 min = 25 hrs)",  5, 32,  1500, "04:32")
+      , ("subtract more than two days"                   ,  2, 20,  3000, "00:20") ]
 
     equalCases =
       [ ("clocks with same time"                                , (15, 37), ( 15,     37), True )

--- a/exercises/complex-numbers/package.yaml
+++ b/exercises/complex-numbers/package.yaml
@@ -1,5 +1,5 @@
 name: complex-numbers
-version: 1.0.0.1
+version: 1.2.0.2
 
 dependencies:
   - base

--- a/exercises/custom-set/package.yaml
+++ b/exercises/custom-set/package.yaml
@@ -1,5 +1,5 @@
 name: custom-set
-version: 1.1.0.4
+version: 1.3.0.5
 
 dependencies:
   - base

--- a/exercises/hamming/package.yaml
+++ b/exercises/hamming/package.yaml
@@ -1,5 +1,5 @@
 name: hamming
-version: 2.0.1.5
+version: 2.1.0.6
 
 dependencies:
   - base

--- a/exercises/kindergarten-garden/package.yaml
+++ b/exercises/kindergarten-garden/package.yaml
@@ -1,5 +1,5 @@
 name: kindergarten-garden
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/ocr-numbers/package.yaml
+++ b/exercises/ocr-numbers/package.yaml
@@ -1,5 +1,5 @@
 name: ocr-numbers
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/prime-factors/package.yaml
+++ b/exercises/prime-factors/package.yaml
@@ -1,5 +1,5 @@
 name: prime-factors
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/queen-attack/package.yaml
+++ b/exercises/queen-attack/package.yaml
@@ -1,5 +1,5 @@
 name: queen-attack
-version: 2.0.0.4
+version: 2.1.0.5
 
 dependencies:
   - base

--- a/exercises/rail-fence-cipher/package.yaml
+++ b/exercises/rail-fence-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: rail-fence-cipher
-version: 1.0.1.2
+version: 1.1.0.3
 
 dependencies:
   - base

--- a/exercises/raindrops/package.yaml
+++ b/exercises/raindrops/package.yaml
@@ -1,5 +1,5 @@
 name: raindrops
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/robot-simulator/package.yaml
+++ b/exercises/robot-simulator/package.yaml
@@ -1,5 +1,5 @@
 name: robot-simulator
-version: 2.0.0.4
+version: 2.2.0.5
 
 dependencies:
   - base

--- a/exercises/roman-numerals/package.yaml
+++ b/exercises/roman-numerals/package.yaml
@@ -1,5 +1,5 @@
 name: roman-numerals
-version: 1.1.0.4
+version: 1.2.0.5
 
 dependencies:
   - base

--- a/exercises/roman-numerals/test/Tests.hs
+++ b/exercises/roman-numerals/test/Tests.hs
@@ -61,6 +61,10 @@ cases = [ Case { description = "1 is a single I"
                , number      = 48
                , expected    = Just "XLVIII"
                }
+        , Case { description = "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
+               , number      = 49
+               , expected    = Just "XLIX"
+               }
         , Case { description = "50 is a single L"
                , number      = 59
                , expected    = Just "LIX"

--- a/exercises/run-length-encoding/package.yaml
+++ b/exercises/run-length-encoding/package.yaml
@@ -1,5 +1,5 @@
 name: run-length-encoding
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/word-count/package.yaml
+++ b/exercises/word-count/package.yaml
@@ -1,5 +1,5 @@
 name: word-count
-version: 1.1.0.4
+version: 1.2.0.5
 
 dependencies:
   - base


### PR DESCRIPTION
still used same script

```ruby
require 'json'
pr = ARGV[0]

exercise = `pwd`.chomp.split(?/).last
ver = JSON.parse(File.read("../../../problem-specifications/exercises/#{exercise}/canonical-data.json"))['version']
haskell_ver = Integer(`grep version: package.yaml`.chomp[-1])

`sed -i'' -e "s/^version: .*/version: #{ver}.#{haskell_ver + 1}/" package.yaml`

m = "#{exercise}: #{ver}.#{haskell_ver + 1}: no-op declare compliance with #{ver}

input object

https://github.com/exercism/problem-specifications/pull/#{pr}"

`git commit --all -m '#{m}'`

puts m
```