### PR TITLE
Remove space from test string.

### DIFF
--- a/exercises/matrix/package.yaml
+++ b/exercises/matrix/package.yaml
@@ -1,5 +1,5 @@
 name: matrix
-version: 1.0.0.4
+version: 1.0.0.5
 
 dependencies:
   - base

--- a/exercises/matrix/test/Tests.hs
+++ b/exercises/matrix/test/Tests.hs
@@ -46,7 +46,7 @@ specs = do
       column 2 (intMatrix "1 2 3\n4 5 6\n7 8 9") `shouldBe` vector [3, 6, 9]
 
     it "can extract column from non-square matrix" $
-      column 2 (intMatrix "1 2 3\n4 5 6\n7 8 9\n 8 7 6") `shouldBe` vector [3, 6, 9, 6]
+      column 2 (intMatrix "1 2 3\n4 5 6\n7 8 9\n8 7 6") `shouldBe` vector [3, 6, 9, 6]
 
     it "extract column where numbers have different widths" $
       column 1 (intMatrix "89 1903 3\n18 3 1\n9 4 800") `shouldBe` vector [1903, 3, 4]


### PR DESCRIPTION
It might seem fair enough to have a space here. But the parsing is quite strict, for example expecting "" to parse to a matrix with 0 rows and 0 columns. So there really shouldn't be an extra space in a space-separated list of values.