### PR TITLE
all-your-base, largest-series-product: Expect specific errors

### DIFF
--- a/config.json
+++ b/config.json
@@ -400,7 +400,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Maybe"
+        "Either"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -410,7 +410,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Maybe"
+        "Either"
       ]
     },
     {

--- a/exercises/all-your-base/examples/success-standard/src/Base.hs
+++ b/exercises/all-your-base/examples/success-standard/src/Base.hs
@@ -1,20 +1,23 @@
-module Base (rebase) where
+module Base (Error(..), rebase) where
 
 import Control.Monad (foldM)
 import Data.List     (unfoldr)
 import Data.Tuple    (swap)
 
-rebase :: Integral a => a -> a -> [a] -> Maybe [a]
+data Error a = InvalidInputBase | InvalidOutputBase | InvalidDigit a
+    deriving (Show, Eq)
+
+rebase :: Integral a => a -> a -> [a] -> Either (Error a) [a]
 rebase ibase obase ds
-    | ibase < 2 = Nothing
-    | obase < 2 = Nothing
+    | ibase < 2 = Left InvalidInputBase
+    | obase < 2 = Left InvalidOutputBase
     | otherwise = toDigits obase <$> fromDigits ibase ds
   where
 
     fromDigits base = foldM f 0
       where
-        f acc x | x >= 0 && x < base = Just (acc * base + x)
-                | otherwise          = Nothing
+        f acc x | x >= 0 && x < base = Right (acc * base + x)
+                | otherwise          = Left (InvalidDigit x)
 
     toDigits base = reverse . unfoldr f
       where

--- a/exercises/all-your-base/src/Base.hs
+++ b/exercises/all-your-base/src/Base.hs
@@ -1,4 +1,7 @@
-module Base (rebase) where
+module Base (Error(..), rebase) where
 
-rebase :: Integral a => a -> a -> [a] -> Maybe [a]
+data Error a = InvalidInputBase | InvalidOutputBase | InvalidDigit a
+    deriving (Show, Eq)
+
+rebase :: Integral a => a -> a -> [a] -> Either (Error a) [a]
 rebase inputBase outputBase inputDigits = error "You need to implement this function."

--- a/exercises/all-your-base/test/Tests.hs
+++ b/exercises/all-your-base/test/Tests.hs
@@ -4,7 +4,7 @@ import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-import Base (rebase)
+import Base (Error(..), rebase)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
@@ -18,11 +18,11 @@ specs = describe "rebase" $ for_ cases test
         assertion  = expression `shouldBe` outputDigits
         expression = rebase inputBase outputBase inputDigits
 
-data Case = Case { description  ::        String
-                 , inputBase    ::        Integer
-                 , inputDigits  ::       [Integer]
-                 , outputBase   ::        Integer
-                 , outputDigits :: Maybe [Integer]
+data Case = Case { description  :: String
+                 , inputBase    :: Integer
+                 , inputDigits  :: [Integer]
+                 , outputBase   :: Integer
+                 , outputDigits :: Either (Error Integer) [Integer]
                  }
 
 cases :: [Case]
@@ -30,49 +30,49 @@ cases = [ Case { description  = "single bit one to decimal"
                , inputBase    = 2
                , inputDigits  = [1]
                , outputBase   = 10
-               , outputDigits = Just [1]
+               , outputDigits = Right [1]
                }
         , Case { description  = "binary to single decimal"
                , inputBase    = 2
                , inputDigits  = [1, 0, 1]
                , outputBase   = 10
-               , outputDigits = Just [5]
+               , outputDigits = Right [5]
                }
         , Case { description  = "single decimal to binary"
                , inputBase    = 10
                , inputDigits  = [5]
                , outputBase   = 2
-               , outputDigits = Just [1, 0, 1]
+               , outputDigits = Right [1, 0, 1]
                }
         , Case { description  = "binary to multiple decimal"
                , inputBase    = 2
                , inputDigits  = [1, 0, 1, 0, 1, 0]
                , outputBase   = 10
-               , outputDigits = Just [4, 2]
+               , outputDigits = Right [4, 2]
                }
         , Case { description  = "decimal to binary"
                , inputBase    = 10
                , inputDigits  = [4, 2]
                , outputBase   = 2
-               , outputDigits = Just [1, 0, 1, 0, 1, 0]
+               , outputDigits = Right [1, 0, 1, 0, 1, 0]
                }
         , Case { description  = "trinary to hexadecimal"
                , inputBase    = 3
                , inputDigits  = [1, 1, 2, 0]
                , outputBase   = 16
-               , outputDigits = Just [2, 10]
+               , outputDigits = Right [2, 10]
                }
         , Case { description  = "hexadecimal to trinary"
                , inputBase    = 16
                , inputDigits  = [2, 10]
                , outputBase   = 3
-               , outputDigits = Just [1, 1, 2, 0]
+               , outputDigits = Right [1, 1, 2, 0]
                }
         , Case { description  = "15-bit integer"
                , inputBase    = 97
                , inputDigits  = [3, 46, 60]
                , outputBase   = 73
-               , outputDigits = Just [6, 10, 45]
+               , outputDigits = Right [6, 10, 45]
                }
 
           -- The following three cases are [0] in all-your-base.json.
@@ -81,79 +81,80 @@ cases = [ Case { description  = "single bit one to decimal"
                , inputBase    = 2
                , inputDigits  = []
                , outputBase   = 10
-               , outputDigits = Just []
+               , outputDigits = Right []
                }
         , Case { description  = "single zero"
                , inputBase    = 10
                , inputDigits  = [0]
                , outputBase   = 2
-               , outputDigits = Just []
+               , outputDigits = Right []
                }
         , Case { description  = "multiple zeros"
                , inputBase    = 10
                , inputDigits  = [0, 0, 0]
                , outputBase   = 2
-               , outputDigits = Just []
+               , outputDigits = Right []
                }
 
         , Case { description  = "leading zeros"
                , inputBase    = 7
                , inputDigits  = [0, 6, 0]
                , outputBase   = 10
-               , outputDigits = Just [4, 2]
+               , outputDigits = Right [4, 2]
                }
         , Case { description  = "input base is one"
                , inputBase    = 1
                , inputDigits  = [0]
                , outputBase   = 10
-               , outputDigits = Nothing
+               , outputDigits = Left InvalidInputBase
                }
         , Case { description  = "input base is zero"
                , inputBase    = 0
                , inputDigits  = []
                , outputBase   = 10
-               , outputDigits = Nothing
+               , outputDigits = Left InvalidInputBase
                }
         , Case { description  = "input base is negative"
                , inputBase    = -2
                , inputDigits  = [1]
                , outputBase   = 10
-               , outputDigits = Nothing
+               , outputDigits = Left InvalidInputBase
                }
         , Case { description  = "negative digit"
                , inputBase    = 2
                , inputDigits  = [1, -1, 1, 0, 1, 0]
                , outputBase   = 10
-               , outputDigits = Nothing
+               , outputDigits = Left (InvalidDigit (-1))
                }
         , Case { description  = "invalid positive digit"
                , inputBase    = 2
                , inputDigits  = [1, 2, 1, 0, 1, 0]
                , outputBase   = 10
-               , outputDigits = Nothing
+               , outputDigits = Left (InvalidDigit 2)
                }
         , Case { description  = "output base is one"
                , inputBase    = 2
                , inputDigits  = [1, 0, 1, 0, 1, 0]
                , outputBase   = 1
-               , outputDigits = Nothing
+               , outputDigits = Left InvalidOutputBase
                }
         , Case { description  = "output base is zero"
                , inputBase    = 10
                , inputDigits  = [7]
                , outputBase   = 0
-               , outputDigits = Nothing
+               , outputDigits = Left InvalidOutputBase
                }
         , Case { description  = "output base is negative"
                , inputBase    = 2
                , inputDigits  = [1]
                , outputBase   = -7
-               , outputDigits = Nothing
+               , outputDigits = Left InvalidOutputBase
                }
         , Case { description  = "both bases are negative"
                , inputBase    = -2
                , inputDigits  = [1]
                , outputBase   = -7
-               , outputDigits = Nothing
+               -- debatable: This could be Left InvalidOutputBase as well.
+               , outputDigits = Left InvalidInputBase
                }
         ]

--- a/exercises/largest-series-product/examples/success-standard/src/Series.hs
+++ b/exercises/largest-series-product/examples/success-standard/src/Series.hs
@@ -1,4 +1,4 @@
-module Series (largestProduct) where
+module Series (Error(..), largestProduct) where
 
 import Control.Monad    ((>=>))
 import Data.Char        (digitToInt, isDigit)
@@ -7,10 +7,16 @@ import Data.Maybe       (mapMaybe)
 import Safe             (maximumMay)
 import Safe.Exact       (takeExactMay)
 
-largestProduct :: (Integral a, Num b, Ord b) => a -> String -> Maybe b
-largestProduct n = traverse charToNum >=> maximumMay . products
+data Error = InvalidSpan | InvalidDigit Char deriving (Show, Eq)
+
+rightOr :: a -> Maybe b -> Either a b
+rightOr a Nothing = Left a
+rightOr _ (Just x) = Right x
+
+largestProduct :: (Integral a, Num b, Ord b) => a -> String -> Either Error b
+largestProduct n = traverse charToNum >=> rightOr InvalidSpan . maximumMay . products
   where
     products = mapMaybe (fmap product . takeExactMay (fromIntegral n)) . tails
     charToNum x
-        | isDigit x = Just . fromIntegral . digitToInt $ x
-        | otherwise = Nothing
+        | isDigit x = Right . fromIntegral . digitToInt $ x
+        | otherwise = Left (InvalidDigit x)

--- a/exercises/largest-series-product/src/Series.hs
+++ b/exercises/largest-series-product/src/Series.hs
@@ -1,4 +1,6 @@
-module Series (largestProduct) where
+module Series (Error(..), largestProduct) where
 
-largestProduct :: Int -> String -> Maybe Integer
+data Error = InvalidSpan | InvalidDigit Char deriving (Show, Eq)
+
+largestProduct :: Int -> String -> Either Error Integer
 largestProduct size digits = error "You need to implement this function."

--- a/exercises/largest-series-product/test/Tests.hs
+++ b/exercises/largest-series-product/test/Tests.hs
@@ -3,7 +3,7 @@
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-import Series (largestProduct)
+import Series (Error(..), largestProduct)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
@@ -13,60 +13,60 @@ specs = describe "largestProduct" $ do
 
       it "finds the largest product if span equals length" $
         largestProduct 2 "29"
-        `shouldBe` Just 18
+        `shouldBe` Right 18
 
       it "can find the largest product of 2 with numbers in order" $
         largestProduct 2 "0123456789"
-        `shouldBe` Just 72
+        `shouldBe` Right 72
 
       it "can find the largest product of 2" $
         largestProduct 2 "576802143"
-        `shouldBe` Just 48
+        `shouldBe` Right 48
 
       it "can find the largest product of 3 with numbers in order" $
         largestProduct 3 "0123456789"
-        `shouldBe` Just 504
+        `shouldBe` Right 504
 
       it "can find the largest product of 3" $
         largestProduct 3 "1027839564"
-        `shouldBe` Just 270
+        `shouldBe` Right 270
 
       it "can find the largest product of 5 with numbers in order" $
         largestProduct 5 "0123456789"
-        `shouldBe` Just 15120
+        `shouldBe` Right 15120
 
       it "can get the largest product of a big number" $
         largestProduct 6 "73167176531330624919225119674426574742355349194934"
-        `shouldBe` Just 23520
+        `shouldBe` Right 23520
 
       it "reports zero if the only digits are zero" $
         largestProduct 2 "0000"
-        `shouldBe` Just 0
+        `shouldBe` Right 0
 
       it "reports zero if all spans include zero" $
         largestProduct 3 "99099"
-        `shouldBe` Just 0
+        `shouldBe` Right 0
 
       it "rejects span longer than string length" $
         largestProduct 4 "123"
-        `shouldBe` Nothing
+        `shouldBe` Left InvalidSpan
 
       it "reports 1 for empty string and empty product (0 span)" $
         largestProduct 0 ""
-        `shouldBe` Just 1
+        `shouldBe` Right 1
 
       it "reports 1 for nonempty string and empty product (0 span)" $
         largestProduct 0 "123"
-        `shouldBe` Just 1
+        `shouldBe` Right 1
 
       it "rejects empty string and nonzero span" $
         largestProduct 1 ""
-        `shouldBe` Nothing
+        `shouldBe` Left InvalidSpan
 
       it "rejects invalid character in digits" $
         largestProduct 2 "1234a5"
-        `shouldBe` Nothing
+        `shouldBe` Left (InvalidDigit 'a')
 
       it "rejects negative span" $
         largestProduct (-1) "12345"
-        `shouldBe` Nothing
+        `shouldBe` Left InvalidSpan


### PR DESCRIPTION
Currently the only two exercises that expect specific errors are:
Bowling:
#441
Forth:
#14

It would be good to encourage the usage of programmatically inspectable
errors in other exercises that can fail in multiple ways.