### PR TITLE
isbn-verifier 2.3.0.4: Use an otherwise-valid ISBN in invalid char test

### DIFF
--- a/exercises/isbn-verifier/package.yaml
+++ b/exercises/isbn-verifier/package.yaml
@@ -1,5 +1,5 @@
 name: isbn-verifier
-version: 2.2.0.3
+version: 2.3.0.4
 
 dependencies:
   - base

--- a/exercises/isbn-verifier/test/Tests.hs
+++ b/exercises/isbn-verifier/test/Tests.hs
@@ -40,7 +40,7 @@ cases = [ Case { description = "valid isbn number"
                , expected    = False
                }
         , Case { description = "invalid character in isbn"
-               , input       = "3-598-2K507-0"
+               , input       = "3-598-P1581-X"
                , expected    = False
                }
         , Case { description = "X is only valid as a check digit"


### PR DESCRIPTION
Set new test case to be 3-598-P1581-X.
This will actually catch incorrect solutions - when invalid characters (P) are treated as 0.
3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 0 * 6 + 1 * 5 + 5 * 4 + 8 * 3 + 1 * 2 + 10 * 1 = 264
264 is divisible by 11.

The previous case did NOT have this property:
3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 0 * 5 + 5 * 4 + 0 * 3 + 7 * 2 + 0 * 1 = 249
249 is NOT divisible by 11.

https://github.com/exercism/problem-specifications/issues/1212
https://github.com/exercism/problem-specifications/pull/1217