### PR TITLE
travis: Display stack version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 -o pack.tgz
  - tar xzf pack.tgz --wildcards --strip-components=1 -C ${HOME}/bin '*/stack'
  - stack --resolver ${RESOLVER} --install-ghc install hlint
+ - stack --version
 
 script:
  - "sh ./bin/ensure-readmes-are-updated.sh"


### PR DESCRIPTION
This will help diagnose any issues that may come up because of differing
stack versions and/or compiled packages.