### PR TITLE
pov 1.3.0.6: add test for paths not involving root

### DIFF
--- a/exercises/pov/package.yaml
+++ b/exercises/pov/package.yaml
@@ -1,5 +1,5 @@
 name: pov
-version: 1.2.0.5
+version: 1.3.0.6
 
 dependencies:
   - base

--- a/exercises/pov/test/Tests.hs
+++ b/exercises/pov/test/Tests.hs
@@ -74,6 +74,12 @@ specs = do
                         , "root"
                         , "c"    ]
 
+      it "Can find path not involving root" $
+        tracePathBetween "x" "sibling-1" rootNotNeeded
+        `shouldBe` Just [ "x"
+                        , "parent"
+                        , "sibling-1" ]
+
       it "Cannot trace if destination does not exist" $
         tracePathBetween "x" "NOT THERE" cousins
         `shouldBe` Nothing
@@ -196,3 +202,12 @@ cousins' = Node "x"
                            ]
                      ]
                ]
+
+rootNotNeeded :: Tree String
+rootNotNeeded = Node "grandparent"
+                    [ Node "parent"
+                          [ leaf "x"
+                          , leaf "sibling-0"
+                          , leaf "sibling-1"
+                          ]
+                    ]


### PR DESCRIPTION
Some implementations choose to always use the root node, even when the
shortest path should not.

https://github.com/exercism/problem-specifications/pull/1227