### PR TITLE
series 1.0.0.3: Add duplicates/long series; Expect (n+1) zero-length series; Change test from ab to 01 

### DIFF
--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -1,18 +1,18 @@
 # Series
 
 Given a string of digits, output all the contiguous substrings of length `n` in
-that string.
+that string in the order that they appear.
 
 For example, the string "49142" has the following 3-digit series:
 
-- 491
-- 914
-- 142
+- "491"
+- "914"
+- "142"
 
 And the following 4-digit series:
 
-- 4914
-- 9142
+- "4914"
+- "9142"
 
 And if you ask for a 6-digit series from a 5-digit string, you deserve
 whatever you get.

--- a/exercises/series/examples/success-byteseqs/src/Series.hs
+++ b/exercises/series/examples/success-byteseqs/src/Series.hs
@@ -5,17 +5,15 @@ import Control.Monad         (guard)
 import Data.ByteString.Char8 (ByteString, foldr, length, tails, take)
 import Data.Function         (on)
 import Data.Maybe            (mapMaybe)
-import Data.Sequence         (Seq, empty, fromList, singleton, (<|))
+import Data.Sequence         (Seq, empty, fromList, (<|))
 import Prelude        hiding (foldr, length, take)
 
 slices :: Num a => Int -> ByteString -> Seq (Seq a)
-slices 0 _  = singleton empty
-slices n bs = fromList
-            . mapMaybe toDigits
-            . takeWhile ((== n) . length)
-            . map (take n)
-            . tails
-            $ bs
+slices n = fromList
+         . mapMaybe toDigits
+         . takeWhile ((== n) . length)
+         . map (take n)
+         . tails
 
 toDigits :: Num a => ByteString -> Maybe (Seq a)
 toDigits = foldr (liftA2 (<|) . toDigit) (Just empty)

--- a/exercises/series/examples/success-standard/src/Series.hs
+++ b/exercises/series/examples/success-standard/src/Series.hs
@@ -4,6 +4,5 @@ import Data.Char (digitToInt)
 import Data.List (tails)
 
 slices :: Int -> String -> [[Int]]
-slices 0 _ = [[]]
 slices n s = map (take n) . take (length s - n + 1) . tails $ numberSeries
     where numberSeries = map digitToInt s

--- a/exercises/series/package.yaml
+++ b/exercises/series/package.yaml
@@ -1,5 +1,5 @@
 name: series
-version: 0.1.0.2
+version: 1.0.0.3
 
 dependencies:
   - base

--- a/exercises/series/test/Tests.hs
+++ b/exercises/series/test/Tests.hs
@@ -30,6 +30,21 @@ specs = do
       slices 3 "012"  `shouldHaveSlices` [[0,1,2]]
       slices 3 "0123" `shouldHaveSlices` [[0,1,2], [1,2,3]]
 
+    it "slices can have duplicates" $
+      slices 3 "777777" `shouldHaveSlices` [[7,7,7], [7,7,7], [7,7,7], [7,7,7]]
+
+    it "slices of a long series" $
+      slices 5 "918493904243" `shouldHaveSlices` [
+          [9,1,8,4,9]
+        , [1,8,4,9,3]
+        , [8,4,9,3,9]
+        , [4,9,3,9,0]
+        , [9,3,9,0,4]
+        , [3,9,0,4,2]
+        , [9,0,4,2,4]
+        , [0,4,2,4,3]
+        ]
+
     it "slices of zero" $ do
       slices 0 ""    `shouldHaveSlices` [[]]
       slices 0 "012" `shouldHaveSlices` [[],[],[],[]]

--- a/exercises/series/test/Tests.hs
+++ b/exercises/series/test/Tests.hs
@@ -26,7 +26,7 @@ specs = do
       slices 2 "01234" `shouldHaveSlices` [[0,1], [1,2], [2,3], [3,4]]
 
     it "slices of three" $ do
-      slices 3 "ab"   `shouldHaveSlices` []
+      slices 3 "01"   `shouldHaveSlices` []
       slices 3 "012"  `shouldHaveSlices` [[0,1,2]]
       slices 3 "0123" `shouldHaveSlices` [[0,1,2], [1,2,3]]
 

--- a/exercises/series/test/Tests.hs
+++ b/exercises/series/test/Tests.hs
@@ -32,4 +32,4 @@ specs = do
 
     it "slices of zero" $ do
       slices 0 ""    `shouldHaveSlices` [[]]
-      slices 0 "012" `shouldHaveSlices` [[]]
+      slices 0 "012" `shouldHaveSlices` [[],[],[],[]]


### PR DESCRIPTION
exercism/problem-specifications#1020

Note that the Haskell track will explicitly differ from the canonical
data in the following ways:

* slice length too long results in no slices, not an error.
* 0 length results in the appropriate number of zero-length slices, not
  an error.