### PR TITLE
comment `library` section's `dependencies:` mapping;  lens-person: remove empty `dependencies:` mapping

### DIFF
--- a/exercises/accumulate/package.yaml
+++ b/exercises/accumulate/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Accumulate
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/acronym/package.yaml
+++ b/exercises/acronym/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Acronym
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/all-your-base/package.yaml
+++ b/exercises/all-your-base/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Base
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/allergies/package.yaml
+++ b/exercises/allergies/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Allergies
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/alphametics/package.yaml
+++ b/exercises/alphametics/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Alphametics
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/anagram/package.yaml
+++ b/exercises/anagram/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Anagram
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/atbash-cipher/package.yaml
+++ b/exercises/atbash-cipher/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Atbash
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/bank-account/package.yaml
+++ b/exercises/bank-account/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: BankAccount
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/beer-song/package.yaml
+++ b/exercises/beer-song/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Beer
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/binary-search-tree/package.yaml
+++ b/exercises/binary-search-tree/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: BST
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/binary/package.yaml
+++ b/exercises/binary/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Binary
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/bob/package.yaml
+++ b/exercises/bob/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Bob
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/bowling/package.yaml
+++ b/exercises/bowling/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Bowling
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/bracket-push/package.yaml
+++ b/exercises/bracket-push/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Brackets
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/change/package.yaml
+++ b/exercises/change/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Change
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/clock/package.yaml
+++ b/exercises/clock/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Clock
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/collatz-conjecture/package.yaml
+++ b/exercises/collatz-conjecture/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: CollatzConjecture
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/complex-numbers/package.yaml
+++ b/exercises/complex-numbers/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: ComplexNumbers
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/connect/package.yaml
+++ b/exercises/connect/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Connect
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/crypto-square/package.yaml
+++ b/exercises/crypto-square/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: CryptoSquare
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/custom-set/package.yaml
+++ b/exercises/custom-set/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: CustomSet
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/diamond/package.yaml
+++ b/exercises/diamond/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Diamond
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/difference-of-squares/package.yaml
+++ b/exercises/difference-of-squares/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Squares
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/dominoes/package.yaml
+++ b/exercises/dominoes/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Dominoes
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/etl/package.yaml
+++ b/exercises/etl/package.yaml
@@ -8,7 +8,7 @@ dependencies:
 library:
   exposed-modules: ETL
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/food-chain/package.yaml
+++ b/exercises/food-chain/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: FoodChain
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/forth/package.yaml
+++ b/exercises/forth/package.yaml
@@ -8,7 +8,7 @@ dependencies:
 library:
   exposed-modules: Forth
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/gigasecond/package.yaml
+++ b/exercises/gigasecond/package.yaml
@@ -8,7 +8,7 @@ dependencies:
 library:
   exposed-modules: Gigasecond
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/go-counting/package.yaml
+++ b/exercises/go-counting/package.yaml
@@ -8,7 +8,7 @@ dependencies:
 library:
   exposed-modules: Counting
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/grade-school/package.yaml
+++ b/exercises/grade-school/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: School
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/grains/package.yaml
+++ b/exercises/grains/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Grains
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/hamming/package.yaml
+++ b/exercises/hamming/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Hamming
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/hello-world/package.yaml
+++ b/exercises/hello-world/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: HelloWorld
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/hexadecimal/package.yaml
+++ b/exercises/hexadecimal/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Hexadecimal
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/house/package.yaml
+++ b/exercises/house/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: House
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/isbn-verifier/package.yaml
+++ b/exercises/isbn-verifier/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: IsbnVerifier
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/isogram/package.yaml
+++ b/exercises/isogram/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Isogram
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/largest-series-product/package.yaml
+++ b/exercises/largest-series-product/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Series
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/leap/package.yaml
+++ b/exercises/leap/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: LeapYear
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/lens-person/examples/success-standard/package.yaml
+++ b/exercises/lens-person/examples/success-standard/package.yaml
@@ -7,7 +7,6 @@ dependencies:
 library:
   exposed-modules: Person
   source-dirs: src
-  dependencies:
 
 tests:
   test:

--- a/exercises/lens-person/package.yaml
+++ b/exercises/lens-person/package.yaml
@@ -8,7 +8,7 @@ dependencies:
 library:
   exposed-modules: Person
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/linked-list/package.yaml
+++ b/exercises/linked-list/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Deque
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/list-ops/package.yaml
+++ b/exercises/list-ops/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: ListOps
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/luhn/package.yaml
+++ b/exercises/luhn/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Luhn
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/matrix/package.yaml
+++ b/exercises/matrix/package.yaml
@@ -8,7 +8,7 @@ dependencies:
 library:
   exposed-modules: Matrix
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/meetup/package.yaml
+++ b/exercises/meetup/package.yaml
@@ -8,7 +8,7 @@ dependencies:
 library:
   exposed-modules: Meetup
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/minesweeper/package.yaml
+++ b/exercises/minesweeper/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Minesweeper
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/nth-prime/package.yaml
+++ b/exercises/nth-prime/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Prime
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/nucleotide-count/package.yaml
+++ b/exercises/nucleotide-count/package.yaml
@@ -8,7 +8,7 @@ dependencies:
 library:
   exposed-modules: DNA
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/ocr-numbers/package.yaml
+++ b/exercises/ocr-numbers/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: OCR
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/octal/package.yaml
+++ b/exercises/octal/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Octal
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/palindrome-products/package.yaml
+++ b/exercises/palindrome-products/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Palindromes
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/pangram/package.yaml
+++ b/exercises/pangram/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Pangram
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/parallel-letter-frequency/package.yaml
+++ b/exercises/parallel-letter-frequency/package.yaml
@@ -9,7 +9,7 @@ dependencies:
 library:
   exposed-modules: Frequency
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/pascals-triangle/package.yaml
+++ b/exercises/pascals-triangle/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Triangle
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/perfect-numbers/package.yaml
+++ b/exercises/perfect-numbers/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: PerfectNumbers
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/phone-number/package.yaml
+++ b/exercises/phone-number/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Phone
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/pig-latin/package.yaml
+++ b/exercises/pig-latin/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: PigLatin
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/poker/package.yaml
+++ b/exercises/poker/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Poker
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/pov/package.yaml
+++ b/exercises/pov/package.yaml
@@ -8,7 +8,7 @@ dependencies:
 library:
   exposed-modules: POV
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/prime-factors/package.yaml
+++ b/exercises/prime-factors/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: PrimeFactors
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/protein-translation/package.yaml
+++ b/exercises/protein-translation/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: ProteinTranslation
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/pythagorean-triplet/package.yaml
+++ b/exercises/pythagorean-triplet/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Triplet
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/queen-attack/package.yaml
+++ b/exercises/queen-attack/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Queens
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/rail-fence-cipher/package.yaml
+++ b/exercises/rail-fence-cipher/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: RailFenceCipher
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/raindrops/package.yaml
+++ b/exercises/raindrops/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Raindrops
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/rna-transcription/package.yaml
+++ b/exercises/rna-transcription/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: DNA
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/robot-name/package.yaml
+++ b/exercises/robot-name/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Robot
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/robot-simulator/package.yaml
+++ b/exercises/robot-simulator/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Robot
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/roman-numerals/package.yaml
+++ b/exercises/roman-numerals/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Roman
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/rotational-cipher/package.yaml
+++ b/exercises/rotational-cipher/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: RotationalCipher
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/run-length-encoding/package.yaml
+++ b/exercises/run-length-encoding/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: RunLength
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/saddle-points/package.yaml
+++ b/exercises/saddle-points/package.yaml
@@ -8,7 +8,7 @@ dependencies:
 library:
   exposed-modules: Matrix
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/say/package.yaml
+++ b/exercises/say/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Say
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/scrabble-score/package.yaml
+++ b/exercises/scrabble-score/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Scrabble
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/secret-handshake/package.yaml
+++ b/exercises/secret-handshake/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: SecretHandshake
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/series/package.yaml
+++ b/exercises/series/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Series
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/sgf-parsing/package.yaml
+++ b/exercises/sgf-parsing/package.yaml
@@ -9,7 +9,7 @@ dependencies:
 library:
   exposed-modules: Sgf
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/sieve/package.yaml
+++ b/exercises/sieve/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Sieve
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/simple-cipher/package.yaml
+++ b/exercises/simple-cipher/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Cipher
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/simple-linked-list/package.yaml
+++ b/exercises/simple-linked-list/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: LinkedList
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/space-age/package.yaml
+++ b/exercises/space-age/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: SpaceAge
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/spiral-matrix/package.yaml
+++ b/exercises/spiral-matrix/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Spiral
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/strain/package.yaml
+++ b/exercises/strain/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Strain
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/sublist/package.yaml
+++ b/exercises/sublist/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Sublist
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/sum-of-multiples/package.yaml
+++ b/exercises/sum-of-multiples/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: SumOfMultiples
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/transpose/package.yaml
+++ b/exercises/transpose/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Transpose
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/triangle/package.yaml
+++ b/exercises/triangle/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Triangle
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/trinary/package.yaml
+++ b/exercises/trinary/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Trinary
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/twelve-days/package.yaml
+++ b/exercises/twelve-days/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: TwelveDays
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/word-count/package.yaml
+++ b/exercises/word-count/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: WordCount
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/wordy/package.yaml
+++ b/exercises/wordy/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: WordProblem
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/zebra-puzzle/package.yaml
+++ b/exercises/zebra-puzzle/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: ZebraPuzzle
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 

--- a/exercises/zipper/package.yaml
+++ b/exercises/zipper/package.yaml
@@ -7,7 +7,7 @@ dependencies:
 library:
   exposed-modules: Zipper
   source-dirs: src
-  dependencies:
+  # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 


### PR DESCRIPTION
It has been observed that with Stack built against certain sets of
dependencies (exact details unknown), using operations such as `stack
test` would result in the following:

    package.yaml: Error while parsing $.library.dependencies - expected Array, Object, or String, encountered Null

This has been observed with Stack 1.6.5 in some circumstances, but not
in the Stack 1.6.5 at https://www.stackage.org/stack/linux-x86_64.

More details as to exactly which versions cause this are unknown because
an investigation was deemed unproductive.

This commit was automatically performed by running:

    sed -i 's/^  dependencies:/  # dependencies:/' */package.yaml

Note that hpack officially does not support null dependencies:

https://github.com/sol/hpack/blob/0.19.0/src/Hpack/Dependency.hs#L52
https://github.com/sol/hpack/blob/0.28.2/src/Hpack/Syntax/Dependency.hs#L60

It may be possible that some support structure around hpack was silently
dropping mapping keys with value null, but this does not seem like wise
behaviour to rely on.

Closes #672