### PR TITLE
stack.yaml: lts-11.19 -> lts-12.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - $HOME/.foldercache # Per exercise `.stack-work` cache.
 
 env:
- - RESOLVER="lts-11.19" CURRENT="YES" # Equal to each stack.yaml.
+ - RESOLVER="lts-12.4" CURRENT="YES"  # Equal to each stack.yaml.
  - RESOLVER="nightly"                 # Latest nightly snapshot.
 
 matrix:

--- a/exercises/accumulate/stack.yaml
+++ b/exercises/accumulate/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/acronym/stack.yaml
+++ b/exercises/acronym/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/all-your-base/stack.yaml
+++ b/exercises/all-your-base/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/allergies/stack.yaml
+++ b/exercises/allergies/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/alphametics/stack.yaml
+++ b/exercises/alphametics/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/anagram/examples/success-settext/package.yaml
+++ b/exercises/anagram/examples/success-settext/package.yaml
@@ -8,7 +8,6 @@ library:
   source-dirs: src
   dependencies:
     - containers
-    - multiset
     - text
 
 tests:

--- a/exercises/anagram/examples/success-settext/src/Anagram.hs
+++ b/exercises/anagram/examples/success-settext/src/Anagram.hs
@@ -1,7 +1,7 @@
 module Anagram (anagramsFor) where
 
 import Data.Function  (on)
-import Data.MultiSet  (fromList)
+import Data.List      (sort)
 import Data.Set       (Set, filter)
 import Data.Text      (Text, toLower, unpack)
 import Prelude hiding (filter)
@@ -10,4 +10,4 @@ anagramsFor :: Text -> Set Text -> Set Text
 anagramsFor x = filter (\w -> x `isDistinctOf` w && x `isAnagramOf` w)
   where
     isDistinctOf = (/=) `on` toLower
-    isAnagramOf  = (==) `on` fromList . unpack . toLower
+    isAnagramOf  = (==) `on` sort . unpack . toLower

--- a/exercises/anagram/stack.yaml
+++ b/exercises/anagram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/atbash-cipher/stack.yaml
+++ b/exercises/atbash-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/bank-account/stack.yaml
+++ b/exercises/bank-account/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/beer-song/stack.yaml
+++ b/exercises/beer-song/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/binary-search-tree/stack.yaml
+++ b/exercises/binary-search-tree/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/binary/stack.yaml
+++ b/exercises/binary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/bob/stack.yaml
+++ b/exercises/bob/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/bowling/stack.yaml
+++ b/exercises/bowling/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/bracket-push/stack.yaml
+++ b/exercises/bracket-push/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/change/stack.yaml
+++ b/exercises/change/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/clock/examples/success-standard/package.yaml
+++ b/exercises/clock/examples/success-standard/package.yaml
@@ -1,4 +1,4 @@
-name: clock
+name: exercism-clock
 
 dependencies:
   - base
@@ -12,5 +12,5 @@ tests:
     main: Tests.hs
     source-dirs: test
     dependencies:
-      - clock
+      - exercism-clock
       - hspec

--- a/exercises/clock/package.yaml
+++ b/exercises/clock/package.yaml
@@ -1,4 +1,4 @@
-name: clock
+name: exercism-clock
 version: 2.2.1.4
 
 dependencies:
@@ -16,5 +16,5 @@ tests:
     main: Tests.hs
     source-dirs: test
     dependencies:
-      - clock
+      - exercism-clock
       - hspec

--- a/exercises/clock/stack.yaml
+++ b/exercises/clock/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/collatz-conjecture/stack.yaml
+++ b/exercises/collatz-conjecture/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/complex-numbers/stack.yaml
+++ b/exercises/complex-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/connect/stack.yaml
+++ b/exercises/connect/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/crypto-square/stack.yaml
+++ b/exercises/crypto-square/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/custom-set/stack.yaml
+++ b/exercises/custom-set/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/diamond/stack.yaml
+++ b/exercises/diamond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/difference-of-squares/stack.yaml
+++ b/exercises/difference-of-squares/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/dominoes/stack.yaml
+++ b/exercises/dominoes/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/etl/stack.yaml
+++ b/exercises/etl/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/food-chain/stack.yaml
+++ b/exercises/food-chain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/forth/stack.yaml
+++ b/exercises/forth/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/gigasecond/stack.yaml
+++ b/exercises/gigasecond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/go-counting/examples/success-standard/package.yaml
+++ b/exercises/go-counting/examples/success-standard/package.yaml
@@ -17,4 +17,3 @@ tests:
     dependencies:
       - go-counting
       - hspec
-      - multiset

--- a/exercises/go-counting/package.yaml
+++ b/exercises/go-counting/package.yaml
@@ -19,4 +19,3 @@ tests:
     dependencies:
       - go-counting
       - hspec
-      - multiset

--- a/exercises/go-counting/stack.yaml
+++ b/exercises/go-counting/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/go-counting/test/Tests.hs
+++ b/exercises/go-counting/test/Tests.hs
@@ -1,9 +1,11 @@
 import Data.Bifunctor    (first)
-import Data.MultiSet     (fromOccurList, toOccurList)
+import Data.List         (foldl')
 import Data.Set          (toAscList)
 import Data.Tuple        (swap)
 import Test.Hspec        (Spec, it, shouldBe, shouldMatchList)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
+import qualified Data.Map as Map
 
 import Counting (Color(Black,White), territories, territoryFor)
 
@@ -23,9 +25,11 @@ specs = do
                               . map (first toAscList)
                               . territories
 
+        add m (owner, size) = Map.insertWith (+) owner size m
+
         shouldScore = shouldMatchList
-                    . toOccurList
-                    . fromOccurList
+                    . Map.toList
+                    . foldl' add Map.empty
                     . map (swap . first length)
                     . territories
 

--- a/exercises/grade-school/stack.yaml
+++ b/exercises/grade-school/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/grains/stack.yaml
+++ b/exercises/grains/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/hamming/stack.yaml
+++ b/exercises/hamming/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/hello-world/stack.yaml
+++ b/exercises/hello-world/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/hexadecimal/stack.yaml
+++ b/exercises/hexadecimal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/house/stack.yaml
+++ b/exercises/house/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/isbn-verifier/stack.yaml
+++ b/exercises/isbn-verifier/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/isogram/stack.yaml
+++ b/exercises/isogram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/kindergarten-garden/stack.yaml
+++ b/exercises/kindergarten-garden/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/largest-series-product/stack.yaml
+++ b/exercises/largest-series-product/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/leap/stack.yaml
+++ b/exercises/leap/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/lens-person/stack.yaml
+++ b/exercises/lens-person/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/linked-list/stack.yaml
+++ b/exercises/linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/list-ops/stack.yaml
+++ b/exercises/list-ops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/luhn/stack.yaml
+++ b/exercises/luhn/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/matrix/stack.yaml
+++ b/exercises/matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/meetup/stack.yaml
+++ b/exercises/meetup/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/minesweeper/stack.yaml
+++ b/exercises/minesweeper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/nth-prime/stack.yaml
+++ b/exercises/nth-prime/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/nucleotide-count/stack.yaml
+++ b/exercises/nucleotide-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/ocr-numbers/stack.yaml
+++ b/exercises/ocr-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/octal/stack.yaml
+++ b/exercises/octal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/palindrome-products/stack.yaml
+++ b/exercises/palindrome-products/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/pangram/stack.yaml
+++ b/exercises/pangram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/parallel-letter-frequency/stack.yaml
+++ b/exercises/parallel-letter-frequency/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/pascals-triangle/stack.yaml
+++ b/exercises/pascals-triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/perfect-numbers/stack.yaml
+++ b/exercises/perfect-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/phone-number/stack.yaml
+++ b/exercises/phone-number/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/pig-latin/stack.yaml
+++ b/exercises/pig-latin/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/poker/stack.yaml
+++ b/exercises/poker/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/pov/stack.yaml
+++ b/exercises/pov/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/prime-factors/stack.yaml
+++ b/exercises/prime-factors/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/protein-translation/stack.yaml
+++ b/exercises/protein-translation/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/pythagorean-triplet/stack.yaml
+++ b/exercises/pythagorean-triplet/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/queen-attack/stack.yaml
+++ b/exercises/queen-attack/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/rail-fence-cipher/stack.yaml
+++ b/exercises/rail-fence-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/raindrops/stack.yaml
+++ b/exercises/raindrops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/rna-transcription/stack.yaml
+++ b/exercises/rna-transcription/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/robot-name/stack.yaml
+++ b/exercises/robot-name/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/robot-simulator/stack.yaml
+++ b/exercises/robot-simulator/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/roman-numerals/stack.yaml
+++ b/exercises/roman-numerals/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/rotational-cipher/stack.yaml
+++ b/exercises/rotational-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/run-length-encoding/stack.yaml
+++ b/exercises/run-length-encoding/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/saddle-points/examples/success-standard/src/Matrix.hs
+++ b/exercises/saddle-points/examples/success-standard/src/Matrix.hs
@@ -23,18 +23,17 @@ instance Extrema Max where
 
 data Extremes a b c = Extremes !a !b !c deriving (Show)
 
-instance (Extrema a, Ord b, Monoid c) => Monoid (Extremes a b c) where
-  mempty = undefined
-  mappend a@(Extremes ea xa as) b@(Extremes _ xb bs) = case ecmp ea xa xb of
+instance (Extrema a, Ord b, Semigroup c) => Semigroup (Extremes a b c) where
+  a@(Extremes ea xa as) <> b@(Extremes _ xb bs) = case ecmp ea xa xb of
     LT -> a
-    EQ -> Extremes ea xa (as `mappend` bs)
+    EQ -> Extremes ea xa (as <> bs)
     GT -> b
 
 extrema :: (Ix a, Ix b, Ord c)
            => Array (a, b) c
            -> M.Map (Axis a b) ( Extremes Min c (S.Set (a, b))
                                , Extremes Max c (S.Set (a, b)))
-extrema = M.fromListWith mappend . expand . assocs
+extrema = M.fromListWith (<>) . expand . assocs
   where expand xs = do
           (ix@(row, col), x) <- xs
           let s = S.singleton ix

--- a/exercises/saddle-points/stack.yaml
+++ b/exercises/saddle-points/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/say/stack.yaml
+++ b/exercises/say/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/scrabble-score/stack.yaml
+++ b/exercises/scrabble-score/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/secret-handshake/stack.yaml
+++ b/exercises/secret-handshake/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/series/stack.yaml
+++ b/exercises/series/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/sgf-parsing/stack.yaml
+++ b/exercises/sgf-parsing/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/sieve/stack.yaml
+++ b/exercises/sieve/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/simple-cipher/stack.yaml
+++ b/exercises/simple-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/simple-linked-list/stack.yaml
+++ b/exercises/simple-linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/space-age/stack.yaml
+++ b/exercises/space-age/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/spiral-matrix/stack.yaml
+++ b/exercises/spiral-matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/strain/stack.yaml
+++ b/exercises/strain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/sublist/stack.yaml
+++ b/exercises/sublist/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/sum-of-multiples/stack.yaml
+++ b/exercises/sum-of-multiples/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/transpose/stack.yaml
+++ b/exercises/transpose/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/triangle/stack.yaml
+++ b/exercises/triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/trinary/stack.yaml
+++ b/exercises/trinary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/twelve-days/stack.yaml
+++ b/exercises/twelve-days/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/word-count/examples/success-newtype/package.yaml
+++ b/exercises/word-count/examples/success-newtype/package.yaml
@@ -7,7 +7,7 @@ library:
   exposed-modules: WordCount
   source-dirs: src
   dependencies:
-    - multiset
+    - containers
     - text
 
 tests:

--- a/exercises/word-count/stack.yaml
+++ b/exercises/word-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/wordy/stack.yaml
+++ b/exercises/wordy/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/zebra-puzzle/stack.yaml
+++ b/exercises/zebra-puzzle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4

--- a/exercises/zipper/stack.yaml
+++ b/exercises/zipper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.19
+resolver: lts-12.4


### PR DESCRIPTION
https://www.stackage.org/diff/lts-11.19/lts-12.4

Last update 4 months ago
https://github.com/exercism/haskell/pull/668

I think it would be interesting to get on GHC 8.4.x, so LTS 12.x is the
ticket.