### PR TITLE
isbn-verifier 2.7.0.8: Replace too long case

### DIFF
--- a/exercises/isbn-verifier/examples/success-standard/src/IsbnVerifier.hs
+++ b/exercises/isbn-verifier/examples/success-standard/src/IsbnVerifier.hs
@@ -6,6 +6,9 @@ isbn xs = length nums == 10 && g nums `mod` 11 == 0 && l <= 1
   where
     nums = let nxs = f xs in if last xs == 'X' then nxs++[(1,10)] else nxs
     f :: String -> [(Int, Int)]
-    f = zip [10,9..1] . map (\x -> read [x]) . filter (`elem` ['0'..'9'])
+    -- for an input that isn't too long, only 10,9..1 should be used
+    -- for an input that's too long, the 0 gets included,
+    -- then the `length nums == 10` rejects it.
+    f = zip [10,9..0] . map (\x -> read [x]) . filter (`elem` ['0'..'9'])
     g = sum . map (uncurry (*))
     l = length $ filter (=='X') xs

--- a/exercises/isbn-verifier/package.yaml
+++ b/exercises/isbn-verifier/package.yaml
@@ -1,5 +1,5 @@
 name: isbn-verifier
-version: 2.6.0.7
+version: 2.7.0.8
 
 dependencies:
   - base

--- a/exercises/isbn-verifier/test/Tests.hs
+++ b/exercises/isbn-verifier/test/Tests.hs
@@ -67,10 +67,6 @@ cases = [ Case { description = "valid isbn number"
                , input       = "3-598-21507"
                , expected    = False
                }
-        , Case { description = "too long isbn"
-               , input       = "3-598-21507-XX"
-               , expected    = False
-               }
         , Case { description = "check digit of X should not be used for 0"
                , input       = "3-598-21515-X"
                , expected    = False
@@ -85,6 +81,10 @@ cases = [ Case { description = "valid isbn number"
                }
         , Case { description = "invalid characters are not ignored"
                , input       = "3132P34035"
+               , expected    = False
+               }
+        , Case { description = "input is too long but contains a valid isbn"
+               , input       = "98245726788"
                , expected    = False
                }
         ]


### PR DESCRIPTION
Handles all three possible implementations:

* Truncate left
* Truncate right
* Consider all 11

https://github.com/exercism/problem-specifications/pull/993#issue-149955212
https://github.com/exercism/problem-specifications/issues/1199
https://github.com/exercism/problem-specifications/pull/1255