### PR TITLE
difference-of-squares: Rename squareOfSums to squareOfSum

### DIFF
--- a/exercises/difference-of-squares/examples/success-standard/src/Squares.hs
+++ b/exercises/difference-of-squares/examples/success-standard/src/Squares.hs
@@ -1,10 +1,10 @@
-module Squares (squareOfSums, sumOfSquares, difference) where
+module Squares (squareOfSum, sumOfSquares, difference) where
 
 square :: Integral a => a -> a
 square n = n * n
 
-squareOfSums :: Integral a => a -> a
-squareOfSums n = square $ n * succ n `div` 2
+squareOfSum :: Integral a => a -> a
+squareOfSum n = square $ n * succ n `div` 2
 
 sumOfSquares :: Integral a => a -> a
 sumOfSquares n = (2 * n3 + 3 * n2 + n) `div` 6
@@ -12,4 +12,4 @@ sumOfSquares n = (2 * n3 + 3 * n2 + n) `div` 6
         n3 = n * n2
 
 difference :: Integral a => a -> a
-difference n = squareOfSums n - sumOfSquares n
+difference n = squareOfSum n - sumOfSquares n

--- a/exercises/difference-of-squares/package.yaml
+++ b/exercises/difference-of-squares/package.yaml
@@ -1,5 +1,5 @@
 name: difference-of-squares
-version: 1.2.0.5
+version: 1.2.0.6
 
 dependencies:
   - base

--- a/exercises/difference-of-squares/src/Squares.hs
+++ b/exercises/difference-of-squares/src/Squares.hs
@@ -1,10 +1,10 @@
-module Squares (difference, squareOfSums, sumOfSquares) where
+module Squares (difference, squareOfSum, sumOfSquares) where
 
 difference :: Integral a => a -> a
 difference n = error "You need to implement this function."
 
-squareOfSums :: Integral a => a -> a
-squareOfSums n = error "You need to implement this function."
+squareOfSum :: Integral a => a -> a
+squareOfSum n = error "You need to implement this function."
 
 sumOfSquares :: Integral a => a -> a
 sumOfSquares n = error "You need to implement this function."

--- a/exercises/difference-of-squares/test/Tests.hs
+++ b/exercises/difference-of-squares/test/Tests.hs
@@ -3,7 +3,7 @@
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-import Squares (difference, squareOfSums, sumOfSquares)
+import Squares (difference, squareOfSum, sumOfSquares)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
@@ -11,10 +11,10 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = do
 
-    describe "squareOfSums" $ do
-      it "square of sum 1"   $ squareOfSums   1 `shouldBe`        1
-      it "square of sum 5"   $ squareOfSums   5 `shouldBe`      225
-      it "square of sum 100" $ squareOfSums 100 `shouldBe` 25502500
+    describe "squareOfSum" $ do
+      it "square of sum 1"   $ squareOfSum   1 `shouldBe`        1
+      it "square of sum 5"   $ squareOfSum   5 `shouldBe`      225
+      it "square of sum 100" $ squareOfSum 100 `shouldBe` 25502500
 
     describe "sumOfSquares" $ do
       it "sum of squares 1"   $ sumOfSquares   1 `shouldBe`      1
@@ -30,14 +30,14 @@ specs = do
 
     describe "Integral tests" $ do
 
-      describe "squareOfSums" $ do
+      describe "squareOfSum" $ do
 
-        it "squareOfSums (6 :: Int)" $
-          squareOfSums (6 :: Int)
+        it "squareOfSum (6 :: Int)" $
+          squareOfSum (6 :: Int)
           `shouldBe` (441 :: Int)
 
-        it "squareOfSums (7 :: Integer)" $
-          squareOfSums (7 :: Integer)
+        it "squareOfSum (7 :: Integer)" $
+          squareOfSum (7 :: Integer)
           `shouldBe` (784 :: Integer)
 
       describe "sumOfSquares" $ do


### PR DESCRIPTION
In the exercise "difference-of-squares", I find the name `squareOfSums` weird, as it returns the square of a single sum. Maybe the name `squareOfSum` is more appropriate.