### PR TITLE
Bob's conversational partner is a purist!

### DIFF
--- a/exercises/bob/examples/success-standard/package.yaml
+++ b/exercises/bob/examples/success-standard/package.yaml
@@ -2,6 +2,7 @@ name: bob
 
 dependencies:
   - base
+  - safe
 
 library:
   exposed-modules: Bob

--- a/exercises/bob/examples/success-standard/src/Bob.hs
+++ b/exercises/bob/examples/success-standard/src/Bob.hs
@@ -1,5 +1,6 @@
 module Bob (responseFor) where
-import Data.Char (isSpace, isUpper, isAlpha)
+import Data.Char (isSpace, isUpper, isAlpha, isPunctuation)
+import Safe (lastMay)
 
 data Prompt = Silence | YellQuestion | Yell | Question | Other
 
@@ -10,7 +11,7 @@ classify s | all isSpace s = Silence
            | question = Question
            | otherwise = Other
            where yell = any isAlpha s && all isUpper (filter isAlpha s)
-                 question = '?' == last (filter (not . isSpace) s)
+                 question = Just '?' == lastMay (filter isPunctuation s)
 
 response :: Prompt -> String
 response Silence = "Fine. Be that way!"

--- a/exercises/bob/package.yaml
+++ b/exercises/bob/package.yaml
@@ -1,5 +1,5 @@
 name: bob
-version: 1.2.0.5
+version: 1.4.0.7
 
 dependencies:
   - base

--- a/exercises/bob/test/Tests.hs
+++ b/exercises/bob/test/Tests.hs
@@ -101,7 +101,7 @@ cases = [ Case { description = "stating something"
                , expected    = "Fine. Be that way!"
                }
         , Case { description = "multiple line question"
-               , input       = "\nDoes this cryogenic chamber make me look fat?\nno"
+               , input       = "\nDoes this cryogenic chamber make me look fat?\nNo."
                , expected    = "Whatever."
                }
         , Case { description = "starting with whitespace"


### PR DESCRIPTION
In the [Bob exercise](https://github.com/exercism/haskell/tree/master/exercises/bob) it says:

> Bob's conversational partner is a purist when it comes to written
> communication and always follows normal rules regarding sentence
> punctuation in English.

But in the unit test the following input is fed to `responseFor`:

    "\nDoes this cryogenic chamber make me look fat?\nno"

This is a rhetorical question, and by the expected value, this is deemed
to not be an actual question, which is very reasonable. But if Bob's
conversational partner is a punctuation purist, it should at least be
"no." with the period.

I found this by wanting to grab the last character that `isPunctuation`,
but had to go with `not . isSpace` (like the reference solution). But
this really sounds wrong when I think about it: I actually want the last
punctuation character and am allowed to assume "normal rules".

Making this change will not render `not . isSpace` solutions wrong.