### PR TITLE
forth 1.6.0.9: Replace duplicated test name with correct name

### DIFF
--- a/exercises/forth/package.yaml
+++ b/exercises/forth/package.yaml
@@ -1,5 +1,5 @@
 name: forth
-version: 1.6.0.8
+version: 1.6.0.9
 
 dependencies:
   - base

--- a/exercises/forth/test/Tests.hs
+++ b/exercises/forth/test/Tests.hs
@@ -125,7 +125,7 @@ specs = do
                  , ": foo 6 ;"
                  , "bar foo"     ] `shouldBe` Right [5, 6]
 
-      it "can use different words with the same name" $
+      it "can define word that uses word with the same name" $
         runTexts [ ": foo 10 ;"
                  , ": foo foo 1 + ;"
                  , "foo"             ] `shouldBe` Right [11]


### PR DESCRIPTION
This was a mistake when applying 1.6.0; I accidentally used the same
test name for the two added tests!
https://github.com/exercism/haskell/pull/700
https://github.com/exercism/problem-specifications/pull/1243