### PR TITLE
Fix code snippets in ABOUT.md and SNIPPET.txt (fixes #708)

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -13,18 +13,5 @@ This lets you safely do weird stuff like operating on an infinite list--the lang
 **Type inference** means that the compiler will often figure out the type of an identifier by itself so you don't have to specify it.
 Scala and later versions of C# both do this.
 
-Haskell syntax is beautiful and minimal.  For example, here is an
-implemention of quicksort in 6 lines:
-
-```haskell
-quicksort :: (Ord a) => [a] -> [a]
-quicksort [] = []
-quicksort (x:xs) =
-    let smallerSorted = quicksort [a | a <- xs, a <= x]
-        biggerSorted  = quicksort [a | a <- xs, a > x]
-    in  smallerSorted ++ [x] ++ biggerSorted
-```
-[(source)](http://learnyouahaskell.com/recursion#quick-sort)
-
 In addition, Haskell is standardized and has multiple high-quality implementations, some of which produce standalone native binaries.
 There is also a collection of free third-party libraries available and a package manager ("cabal") to automatically fetch them for you.

--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,4 +1,9 @@
-module HelloWorld (hello) where
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+import Web.Scotty
 
-hello :: String
-hello = "Hello, World!"
+main = scotty 3000 $
+  get "/:who" $ do
+    who <- param "who"
+    text $
+      "Beam " <> who <> " up, Scotty!"


### PR DESCRIPTION
Fix code snippets in ABOUT.md and SNIPPET.txt (fixes #708)

This commit
    
 - Removes the Quicksort code example from ABOUT.md as #686 dictates.
 - Adds a real-world web-server example (Scotty) within 38x9 characters.
 - Removes the sentence "Haskell syntax is beautiful and minimal."
   because it tied to the code snippet, not because it isn't true. ;-)

The snippet comes from http://hackage.haskell.org/package/scotty-0.11.2