### PR TITLE
Improve about page

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,17 +1,15 @@
-Haskell is a purely functional, lazy, statically-typed programming language with type inference.
+Haskell is a general-purpose programming language known for being purely functional, non-strict with strong static typing and for having type inference.
 
-**Functional** means that functions are first-class data types.
+**Purely functional** means that you don't update variables or modify state.
+Pure functions will always return the same value given the same input and will do nothing else.
+Functions that are [referentially transparent](https://medium.com/@olxc/referential-transparency-93352c2dd713) are more predictable and more composable.
+**Non-strict** (somewhat like [lazy](https://wiki.haskell.org/Lazy_vs._non-strict)) means that you can express infinite data structures.
+**Strong static typing** means that a lot of program errors are caught during compilation.
+**Type inference** means that the compiler can often figure out the type of a value by itself.
+The compiler can also tell you if a value has conflicting types in different parts of the code.
 
-**Purely Functional** means (roughly) that there are no side effects.
-Every function will always return the same value for a given argument will do nothing else.
+There are more than 10,000 free third-party packages available at [Hackage](https://hackage.haskell.org/), the Haskell community's central package archive,
+and you can download them using the [Stack](https://haskellstack.org/) tool that Exercism also uses.
 
-**Lazy** (a.k.a "non-strict") means that the compiler will put off evaluating a thing until absolutely neccessary.
-This lets you safely do weird stuff like operating on an infinite list--the language will only create it up to the last value you actually use.
-
-**Statically-typed** means that identifiers have a type set at compile time--like those in Java, C++ or C#--instead of holding data of any type like those in Python, Ruby or JavaScript.
-
-**Type inference** means that the compiler will often figure out the type of an identifier by itself so you don't have to specify it.
-Scala and later versions of C# both do this.
-
-In addition, Haskell is standardized and has multiple high-quality implementations, some of which produce standalone native binaries.
-There is also a collection of free third-party libraries available and a package manager ("cabal") to automatically fetch them for you.
+You can also read the free book [Learn You a Haskell for Great Good](http://learnyouahaskell.com/)
+or follow the interactive tutorial at [tryhaskell.org](https://www.tryhaskell.org/).


### PR DESCRIPTION
I've tried to make the About page conform to [exercism/language-tracks/documentation/introductory-copy.md][1]:

 - Slightly less detail.
 - More readable to non-Haskellers.
 - Shortened from ~200 words to ~160 words.
 - Modelled on [the Go track][2]'s About page.
 - Added links to LYAH and tryhaskell.org, Hackage, Stack.
 - Preserved sentences one per line, but such that they render in fewer paragraphs.

It still does not mention history, design goals, or what Haskell is great for.

It no longer has comparisons to other languages. It could have.

[1]: https://github.com/exercism/docs/blob/master/language-tracks/documentation/introductory-copy.md#code-snippet
[2]: https://github.com/exercism/go/blob/master/docs/ABOUT.md