### PR TITLE
phone-number 1.5.0.6: add cases to test data that cover invalid use of "1" or "0"

### DIFF
--- a/exercises/phone-number/package.yaml
+++ b/exercises/phone-number/package.yaml
@@ -1,5 +1,5 @@
 name: phone-number
-version: 1.4.0.5
+version: 1.5.0.6
 
 dependencies:
   - base

--- a/exercises/phone-number/test/Tests.hs
+++ b/exercises/phone-number/test/Tests.hs
@@ -53,6 +53,22 @@ cases =
            , input       = "321234567890"
            , expected    = Nothing
            }
+    , Case { description = "invalid if area code starts with 0 on valid 11-digit number"
+           , input       = "1 (023) 456-7890"
+           , expected    = Nothing
+           }
+    , Case { description = "invalid if area code starts with 1 on valid 11-digit number"
+           , input       = "1 (123) 456-7890"
+           , expected    = Nothing
+           }
+    , Case { description = "invalid if exchange code starts with 0 on valid 11-digit number"
+           , input       = "1 (223) 056-7890"
+           , expected    = Nothing
+           }
+    , Case { description = "invalid if exchange code starts with 1 on valid 11-digit number"
+           , input       = "1 (223) 156-7890"
+           , expected    = Nothing
+           }
     , Case { description = "invalid with letters"
            , input       = "123-abc-7890"
            , expected    = Nothing


### PR DESCRIPTION
This should catch solutions with a validation function that calls itself recursively when the first digit is '1'.

Addresses exercism/problem-specifications#1325