### PR TITLE
Add topics to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,7 +22,9 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": []
+      "topics": [
+        "booleans"
+      ]
     },
     {
       "slug": "space-age",

--- a/config.json
+++ b/config.json
@@ -32,7 +32,9 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": []
+      "topics": [
+        "discriminated_unions"
+      ]
     },
     {
       "slug": "bob",


### PR DESCRIPTION
Perhaps I don't understand the policy of [TOPICS.txt](https://github.com/exercism/problem-specifications/blob/master/TOPICS.txt); some of the topics there would not make sense to add to Haskell exercises; e.g. recursion, pattern matching and polymorphism would appear excessively. But perhaps on the first exercise that aims to teach those it would make sense.

With that in mind I've added two topics.