### PR TITLE
Changing robot-name to use StateT

### DIFF
--- a/exercises/robot-name/.meta/hints.md
+++ b/exercises/robot-name/.meta/hints.md
@@ -1,12 +1,18 @@
 ## Hints
 
 To complete this exercise, you need to create the data type `Robot`,
-as a mutable variable, and implement the following functions:
+as a mutable variable, and the data type `RunState`. You also need to
+implement the following functions:
 
+- `initialState`
 - `mkRobot`
 - `resetName`
 - `robotName`
 
 You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,
-newtype or type synonym.
+newtype or type synonym. To model state this exercise uses the
+[`State`](https://en.wikibooks.org/wiki/Haskell/Understanding_monads/State)
+monad. More specifically we combine the `State` monad with the `IO` monad using
+the [`StateT` monad transfomers](http://book.realworldhaskell.org/read/monad-transformers.html).
+All tests are run with `initialState` as the state fed into to `evalStateT`.

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -18,15 +18,21 @@ every existing robot has a unique name.
 ## Hints
 
 To complete this exercise, you need to create the data type `Robot`,
-as a mutable variable, and implement the following functions:
+as a mutable variable, and the data type `RunState`. You also need to
+implement the following functions:
 
+- `initialState`
 - `mkRobot`
 - `resetName`
 - `robotName`
 
 You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,
-newtype or type synonym.
+newtype or type synonym. To model state this exercise uses the
+[`State`](https://en.wikibooks.org/wiki/Haskell/Understanding_monads/State)
+monad. More specifically we combine the `State` monad with the `IO` monad using
+the [`StateT` monad transfomers](http://book.realworldhaskell.org/read/monad-transformers.html).
+All tests are run with `initialState` as the state fed into to `evalStateT`.
 
 
 

--- a/exercises/robot-name/examples/fail-no-collision-testing/package.yaml
+++ b/exercises/robot-name/examples/fail-no-collision-testing/package.yaml
@@ -1,0 +1,19 @@
+name: robot-name
+
+dependencies:
+  - base
+  - mtl
+
+library:
+  exposed-modules: Robot
+  source-dirs: src
+  dependencies:
+    - random
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - robot-name
+      - hspec

--- a/exercises/robot-name/examples/fail-no-collision-testing/src/Robot.hs
+++ b/exercises/robot-name/examples/fail-no-collision-testing/src/Robot.hs
@@ -1,0 +1,28 @@
+module Robot (Robot, initialState, mkRobot, resetName, robotName) where
+
+import           Control.Concurrent.MVar (MVar, newMVar, readMVar, swapMVar)
+import           Control.Monad           (void)
+import           Control.Monad.State     (StateT)
+import           Control.Monad.Trans     (lift)
+import           System.Random           (randomRIO)
+
+newtype Robot = Robot { robotNameVar :: MVar String }
+type RunState = ()
+
+initialState :: RunState
+initialState = ()
+
+randomName :: IO String
+randomName = mapM randomRIO [letter, letter, digit, digit, digit]
+  where
+    letter = ('A', 'Z')
+    digit = ('0', '9')
+
+mkRobot :: StateT RunState IO Robot
+mkRobot = Robot <$> lift (randomName >>= newMVar)
+
+resetName :: Robot -> StateT RunState IO ()
+resetName (Robot name) = void . lift $ randomName >>= swapMVar name
+
+robotName :: Robot -> IO String
+robotName = readMVar . robotNameVar

--- a/exercises/robot-name/examples/success-standard/package.yaml
+++ b/exercises/robot-name/examples/success-standard/package.yaml
@@ -2,11 +2,13 @@ name: robot-name
 
 dependencies:
   - base
+  - mtl
 
 library:
   exposed-modules: Robot
   source-dirs: src
   dependencies:
+    - containers
     - random
 
 tests:

--- a/exercises/robot-name/examples/success-standard/src/Robot.hs
+++ b/exercises/robot-name/examples/success-standard/src/Robot.hs
@@ -1,22 +1,44 @@
-module Robot (Robot, mkRobot, robotName, resetName) where
+module Robot (Robot, initialState, mkRobot, resetName, robotName) where
 
-import Control.Concurrent (MVar, readMVar, swapMVar, newMVar)
-import Control.Monad (void)
-import System.Random (randomRIO)
+import           Control.Concurrent.MVar (MVar, newMVar, putMVar, readMVar,
+                                          takeMVar)
+import           Control.Monad.State     (StateT, get, modify)
+import           Control.Monad.Trans     (lift)
+import           Data.Set                (Set)
+import qualified Data.Set                as S
+import           System.Random           (randomRIO)
 
 newtype Robot = Robot { robotNameVar :: MVar String }
+type RunState = Set String
 
-mkRobot :: IO Robot
-mkRobot = fmap Robot $ generateName >>= newMVar
+initialState :: RunState
+initialState = S.empty
 
-resetName :: Robot -> IO ()
-resetName r = void (generateName >>= swapMVar (robotNameVar r))
+randomName :: IO String
+randomName = mapM randomRIO [letter, letter, digit, digit, digit]
+  where
+    letter = ('A', 'Z')
+    digit = ('0', '9')
+
+randomUniqueName :: StateT RunState IO String
+randomUniqueName = do
+  name <- lift randomName
+  nameSpace <- get
+  if name `S.member` nameSpace
+    then randomUniqueName
+    else do
+      modify (S.insert name)
+      return name
+
+mkRobot :: StateT RunState IO Robot
+mkRobot = fmap Robot $ randomUniqueName >>= lift . newMVar
+
+resetName :: Robot -> StateT RunState IO ()
+resetName (Robot name) = do
+  oldName <- lift $ takeMVar name
+  randomUniqueName >>= lift . putMVar name
+  modify (S.delete oldName)
+
 
 robotName :: Robot -> IO String
 robotName = readMVar . robotNameVar
-
-generateName :: IO String
-generateName = mapM randomRIO [ letter, letter, digit, digit, digit ]
-  where
-    letter = ('A', 'Z')
-    digit  = ('0', '9')

--- a/exercises/robot-name/package.yaml
+++ b/exercises/robot-name/package.yaml
@@ -1,8 +1,9 @@
 name: robot-name
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
+  - mtl
 
 library:
   exposed-modules: Robot

--- a/exercises/robot-name/src/Robot.hs
+++ b/exercises/robot-name/src/Robot.hs
@@ -1,11 +1,17 @@
-module Robot (Robot, mkRobot, resetName, robotName) where
+module Robot (Robot, initialState, mkRobot, resetName, robotName) where
 
-data Robot = Dummy
+import Control.Monad.State (StateT)
 
-mkRobot :: IO Robot
+data Robot = Dummy1
+data RunState = Dummy2
+
+initialState :: RunState
+initialState = error "You need to implement this function"
+
+mkRobot :: StateT RunState IO Robot
 mkRobot = error "You need to implement this function."
 
-resetName :: Robot -> IO ()
+resetName :: Robot -> StateT RunState IO ()
 resetName robot = error "You need to implement this function."
 
 robotName :: Robot -> IO String

--- a/exercises/robot-name/test/Tests.hs
+++ b/exercises/robot-name/test/Tests.hs
@@ -3,11 +3,10 @@
 import Control.Monad       (replicateM, unless)
 import Control.Monad.State (evalStateT)
 import Control.Monad.Trans (lift)
-
-import Data.Ix           (inRange)
-import Data.List         (group, intercalate, null, sort)
-import Test.Hspec        (Spec, expectationFailure, it, shouldBe, shouldNotBe, shouldSatisfy)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Data.Ix             (inRange)
+import Data.List           (group, intercalate, null, sort)
+import Test.Hspec          (Spec, expectationFailure, it, shouldBe, shouldNotBe, shouldSatisfy)
+import Test.Hspec.Runner   (configFastFail, defaultConfig, hspecWith)
 
 import Robot (initialState, mkRobot, resetName, robotName)
 

--- a/exercises/robot-name/test/Tests.hs
+++ b/exercises/robot-name/test/Tests.hs
@@ -1,10 +1,13 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
+import Control.Monad.State (evalStateT)
+import Control.Monad.Trans (lift)
+
 import Data.Ix           (inRange)
 import Test.Hspec        (Spec, it, shouldBe, shouldNotBe, shouldSatisfy)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-import Robot (mkRobot, resetName, robotName)
+import Robot (initialState, mkRobot, resetName, robotName)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
@@ -28,42 +31,48 @@ specs = do
                 n3 <- robotName r
                 n1 `shouldBe` n2
                 n1 `shouldBe` n3
+          let evalWithInitial = flip evalStateT initialState
 
           it "name should match expected pattern" $
-            mkRobot >>= robotName >>= (`shouldSatisfy` matchesPattern)
+            evalWithInitial mkRobot >>= robotName >>= (`shouldSatisfy` matchesPattern)
 
           it "name is persistent" $
-            mkRobot >>= testPersistence
+            evalWithInitial mkRobot >>= testPersistence
 
-          it "different robots have different names" $ do
-            n1 <- mkRobot >>= robotName
-            n2 <- mkRobot >>= robotName
-            n1 `shouldNotBe` n2
+          it "different robots have different names" $
+            evalWithInitial $ do
+              n1 <- mkRobot >>= lift . robotName
+              n2 <- mkRobot >>= lift . robotName
+              lift $ n1 `shouldNotBe` n2
 
-          it "new name should match expected pattern" $ do
-            r <- mkRobot
-            resetName r
-            robotName r >>= (`shouldSatisfy` matchesPattern)
+          it "new name should match expected pattern" $
+            evalWithInitial $ do
+              r <- mkRobot
+              resetName r
+              lift $ robotName r >>= (`shouldSatisfy` matchesPattern)
 
-          it "new name is persistent" $ do
-            r <- mkRobot
-            resetName r >> testPersistence r
+          it "new name is persistent" $
+            evalWithInitial $ do
+              r <- mkRobot
+              resetName r >> lift (testPersistence r)
 
-          it "new name is different from old name" $ do
-            r <- mkRobot
-            n1 <- robotName r
-            resetName r
-            n2 <- robotName r
-            n1 `shouldNotBe` n2
+          it "new name is different from old name" $
+            evalWithInitial $ do
+              r <- mkRobot
+              n1 <- lift $ robotName r
+              resetName r
+              n2 <- lift $ robotName r
+              lift $ n1 `shouldNotBe` n2
 
-          it "resetting a robot affects only one robot" $ do
-            r1 <- mkRobot
-            r2 <- mkRobot
-            n1 <- robotName r1
-            n2 <- robotName r2
-            n1 `shouldNotBe` n2
-            resetName r1
-            n1' <- robotName r1
-            n2' <- robotName r2
-            n1' `shouldNotBe` n2'
-            n2  `shouldBe`    n2'
+          it "resetting a robot affects only one robot" $
+            evalWithInitial $ do
+              r1 <- mkRobot
+              r2 <- mkRobot
+              n1 <- lift $ robotName r1
+              n2 <- lift $ robotName r2
+              lift $ n1 `shouldNotBe` n2
+              resetName r1
+              n1' <- lift $ robotName r1
+              n2' <- lift $ robotName r2
+              lift $ n1' `shouldNotBe` n2'
+              lift $ n2  `shouldBe`    n2'


### PR DESCRIPTION
Altered the type signatures in the exercise, the testing suite and the example solution to use the StateT monad transformer.