### PR TITLE
clock 2.2.1.6: Remove clockHour and clockMin

### DIFF
--- a/exercises/clock/.meta/hints.md
+++ b/exercises/clock/.meta/hints.md
@@ -4,8 +4,6 @@ To complete this exercise you need to define the data type `Clock`,
 with `Eq` and `Show` instances, and implement the functions:
 
 - addDelta
-- clockHour
-- clockMin
 - fromHourMin
 - toString
 

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -12,8 +12,6 @@ To complete this exercise you need to define the data type `Clock`,
 with `Eq` and `Show` instances, and implement the functions:
 
 - addDelta
-- clockHour
-- clockMin
 - fromHourMin
 - toString
 

--- a/exercises/clock/examples/success-standard/src/Clock.hs
+++ b/exercises/clock/examples/success-standard/src/Clock.hs
@@ -1,4 +1,4 @@
-module Clock (addDelta, clockHour, clockMin, fromHourMin, toString) where
+module Clock (addDelta, fromHourMin, toString) where
 import Text.Printf (printf)
 
 newtype Clock = Clock { unClock :: Int } deriving (Show, Eq)

--- a/exercises/clock/package.yaml
+++ b/exercises/clock/package.yaml
@@ -1,5 +1,5 @@
 name: exercism-clock
-version: 2.2.1.5
+version: 2.2.1.6
 
 dependencies:
   - base

--- a/exercises/clock/src/Clock.hs
+++ b/exercises/clock/src/Clock.hs
@@ -1,12 +1,6 @@
-module Clock (addDelta, clockHour, clockMin, fromHourMin, toString) where
+module Clock (addDelta, fromHourMin, toString) where
 
 data Clock = Dummy
-
-clockHour :: Clock -> Int
-clockHour clock = error "You need to implement this function."
-
-clockMin :: Clock -> Int
-clockMin clock = error "You need to implement this function."
 
 fromHourMin :: Int -> Int -> Clock
 fromHourMin hour min = error "You need to implement this function."


### PR DESCRIPTION
Ever since the clock exercise was implemented for Haskell track in
https://github.com/exercism/haskell/pull/12, the tests have never
required clockHour nor clockMin; it was an internal function used by the
example solution.

when stub was added for clock (and other exercises) in July 2016 in
https://github.com/exercism/haskell/pull/200 the clockHour and clockMin
were added to the stub.

It doesn't seem to make sense to include untested functions in the stub,
plus there does not seem to be any particular value in testing these
separately (rather than the current approach of just testing toString),
so the solution is to remove them.