### PR TITLE
perfect-numbers 1.1.0.3: Explicitly list imports of PerfectNumbers

### DIFF
--- a/exercises/perfect-numbers/package.yaml
+++ b/exercises/perfect-numbers/package.yaml
@@ -1,5 +1,5 @@
 name: perfect-numbers
-version: 1.1.0.2
+version: 1.1.0.3
 
 dependencies:
   - base

--- a/exercises/perfect-numbers/test/Tests.hs
+++ b/exercises/perfect-numbers/test/Tests.hs
@@ -4,7 +4,7 @@ import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-import PerfectNumbers
+import PerfectNumbers (Classification(Deficient, Perfect, Abundant), classify)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs


### PR DESCRIPTION
Two benefits:

* Make tests clearer to a reader of this file
* Prevent accidental ambiguity in imports (what if a PerfectNumbers
  decides to include a `describe` function?)