### PR TITLE
complex-numbers 1.3.0.4: Explicitly list test's imports of ComplexNumbers

### DIFF
--- a/exercises/complex-numbers/package.yaml
+++ b/exercises/complex-numbers/package.yaml
@@ -1,5 +1,5 @@
 name: complex-numbers
-version: 1.3.0.3
+version: 1.3.0.4
 
 dependencies:
   - base

--- a/exercises/complex-numbers/test/Tests.hs
+++ b/exercises/complex-numbers/test/Tests.hs
@@ -6,6 +6,16 @@ import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
 import ComplexNumbers
+  ( conjugate
+  , abs
+  , real
+  , imaginary
+  , mul
+  , add
+  , sub
+  , div
+  , complex
+  )
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs


### PR DESCRIPTION
Two benefits:

* Make tests clearer to a reader of this file
* Prevent accidental ambiguity in imports (what if a ComplexNumbers
  decides to include a `describe` function?)