### PR TITLE
anagram-1.4.0: words are not anagrams of themselves

### DIFF
--- a/exercises/anagram/package.yaml
+++ b/exercises/anagram/package.yaml
@@ -1,5 +1,5 @@
 name: anagram
-version: 1.2.0.6
+version: 1.4.0.7
 
 dependencies:
   - base

--- a/exercises/anagram/test/Tests.hs
+++ b/exercises/anagram/test/Tests.hs
@@ -85,9 +85,9 @@ cases = [ Case { description = "no matches"
                , candidates  = ["patter"]
                , expected    = []
                }
-        , Case { description = "capital word is not own anagram"
+        , Case { description = "words are not anagrams of themselves (case-insensitive)"
                , subject     = "BANANA"
-               , candidates  = ["Banana"]
+               , candidates  = ["BANANA", "Banana", "banana"]
                , expected    = []
                }
         ]


### PR DESCRIPTION
Addresses exercism/problem-specifications#1348.

The two unaccounted version bumps are no-ops:
 - 1.2.0 -> 1.2.1: A comment was changed in [1].
 - 1.2.1 -> 1.3.0: The `property` value was changed from `anagrams` to
   `findAnagrams` in [2], but we call this function `anagramsFor`, so it
   seems that we don't aim for conformity here.

[1]: exercism/problem-specifications@725b76723b14391724ba711c45d6610b0d32feb2
[2]: exercism/problem-specifications@3faf343b955dd86fed103364314b8b29b64c7761