### PR TITLE
test-example: support runghc without stack

### DIFF
--- a/bin/test-example
+++ b/bin/test-example
@@ -59,25 +59,43 @@ runstack () {
              # the 50 minutes limit.
 }
 
+nostack() {
+  if [ "$1" = "test" ]; then
+    # TODO: Ignores --no-run-tests used for `error`
+    # TODO: runghc doesn't allow use of -O flag,
+    # thus some exercises' tests are a bit slow.
+    runghc -Wall -isrc test/Tests.hs
+  #elif [ "$1" = "build" ]; then
+    # TODO: used in `fail` type to make sure that build doesn't fail,
+    # despite tests failing
+  fi
+}
+
+if [ -n "$NOSTACK" ]; then
+  run=nostack
+else
+  run=runstack
+fi
+
 if [ "$exampletype" = "success" ]; then
     echo "testing ${exampledir} - should succeed"
     # Implicit exit value: this is last thing in this path,
     # so the script's exit value = stack's exit value.
     # If statements are reordered, please preserve this property.
-    runstack "test"
+    $run "test"
 elif [ "$exampletype" = "fail" ]; then
     echo "testing ${exampledir} - should build, but fail tests"
-    if ! runstack "build"; then
+    if ! $run "build"; then
         echo "${exampledir} build failed unexpectedly"
         exit 1
     fi
-    if runstack "test"; then
+    if $run "test"; then
         echo "${exampledir} test succeeded unexpectedly"
         exit 1
     fi
 elif [ "$exampletype" = "error" ]; then
     echo "testing ${exampledir} - should fail to build"
-    if runstack "test" "--no-run-tests"; then
+    if $run "test" "--no-run-tests"; then
         echo "${exampledir} build succeeded unexpectedly"
         exit 1
     else


### PR DESCRIPTION
I'm no longer able to run hspec 2.5.0 on at least one machine I own, for
Reasons (filesystems mounted noexec). Allow the environment variable
NOSTACK to signify not using Stack.

Slightly incomplete for `build` and `test`, but good enough for now.
