### PR TITLE
sum-of-multiples: describe the importance of each test (test version 1.4.1, closes #738)

### DIFF
--- a/exercises/sum-of-multiples/package.yaml
+++ b/exercises/sum-of-multiples/package.yaml
@@ -1,5 +1,5 @@
 name: sum-of-multiples
-version: 1.4.0.7
+version: 1.4.1.8
 
 dependencies:
   - base

--- a/exercises/sum-of-multiples/package.yaml
+++ b/exercises/sum-of-multiples/package.yaml
@@ -1,5 +1,5 @@
 name: sum-of-multiples
-version: 1.3.0.6
+version: 1.4.0.7
 
 dependencies:
   - base

--- a/exercises/sum-of-multiples/test/Tests.hs
+++ b/exercises/sum-of-multiples/test/Tests.hs
@@ -82,4 +82,8 @@ cases = [ Case { factors  = [3, 5]
                , limit    = 1
                , expected = 0
                }
+        , Case { factors  = [2, 3, 5, 7, 11]
+               , limit    = 10000
+               , expected = 39614537
+               }
         ]

--- a/exercises/sum-of-multiples/test/Tests.hs
+++ b/exercises/sum-of-multiples/test/Tests.hs
@@ -13,77 +13,93 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = describe "sumOfMultiples" $ for_ cases test
   where
-    test Case{..} = it description assertion
+    test Case{..} = it description' assertion
       where
-        description = unwords [show factors, show limit]
+        description' = unwords [show factors, show limit, "--", description]
         assertion   = expression `shouldBe` fromIntegral expected
         expression  = sumOfMultiples (fromIntegral <$> factors)
                                      (fromIntegral     limit  )
 
-data Case = Case { factors  :: [Integer]
-                 , limit    ::  Integer
-                 , expected ::  Integer
+data Case = Case { factors     :: [Integer]
+                 , limit       ::  Integer
+                 , expected    ::  Integer
+                 , description ::  String
                  }
 
 cases :: [Case]
 cases = [ Case { factors  = [3, 5]
                , limit    = 1
                , expected = 0
+               , description = "no multiples within limit"
                }
         , Case { factors  = [3, 5]
                , limit    = 4
                , expected = 3
+               , description = "one factor has multiples within limit"
                }
         , Case { factors  = [3]
                , limit    = 7
                , expected = 9
+               , description = "more than one multiple within limit"
                }
         , Case { factors  = [3, 5]
                , limit    = 10
                , expected = 23
+               , description = "more than one factor with multiples within limit"
                }
         , Case { factors  = [3, 5]
                , limit    = 100
                , expected = 2318
+               , description = "each multiple is only counted once"
                }
         , Case { factors  = [3, 5]
                , limit    = 1000
                , expected = 233168
+               , description = "a much larger limit"
                }
         , Case { factors  = [7, 13, 17]
                , limit    = 20
                , expected = 51
+               , description = "three factors"
                }
         , Case { factors  = [4, 6]
                , limit    = 15
                , expected = 30
+               , description = "factors not relatively prime"
                }
         , Case { factors  = [5, 6, 8]
                , limit    = 150
                , expected = 4419
+               , description = "some pairs of factors relatively prime and some not"
                }
         , Case { factors  = [5, 25]
                , limit    = 51
                , expected = 275
+               , description = "one factor is a multiple of another"
                }
         , Case { factors  = [43, 47]
                , limit    = 10000
                , expected = 2203160
+               , description = "much larger factors"
                }
         , Case { factors  = [1]
                , limit    = 100
                , expected = 4950
+               , description = "all numbers are multiples of 1"
                }
         , Case { factors  = []
                , limit    = 10000
                , expected = 0
+               , description = "no factors means an empty sum"
                }
         , Case { factors  = [0]
                , limit    = 1
                , expected = 0
+               , description = "the only multiple of 0 is 0"
                }
         , Case { factors  = [2, 3, 5, 7, 11]
                , limit    = 10000
                , expected = 39614537
+               , description = "solutions using include-exclude must extend to cardinality greater than 3"
                }
         ]


### PR DESCRIPTION
**Edit:** This bumps version to 1.4.1, so it should be applied after #741, which bumps it to 1.4.0.

I apologize for being chronologically challenged. :-D