### PR TITLE
Removed mention of `Show` from README.

### DIFF
--- a/exercises/clock/.meta/hints.md
+++ b/exercises/clock/.meta/hints.md
@@ -1,7 +1,7 @@
 ## Hints
 
 To complete this exercise you need to define the data type `Clock`,
-with `Eq` and `Show` instances, and implement the functions:
+add an `Eq` instance, and implement the functions:
 
 - addDelta
 - fromHourMin

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -9,7 +9,7 @@ Two clocks that represent the same time should be equal to each other.
 ## Hints
 
 To complete this exercise you need to define the data type `Clock`,
-with `Eq` and `Show` instances, and implement the functions:
+add an `Eq` instance, and implement the functions:
 
 - addDelta
 - fromHourMin

--- a/exercises/clock/examples/success-standard/src/Clock.hs
+++ b/exercises/clock/examples/success-standard/src/Clock.hs
@@ -1,7 +1,7 @@
 module Clock (addDelta, fromHourMin, toString) where
 import Text.Printf (printf)
 
-newtype Clock = Clock { unClock :: Int } deriving (Show, Eq)
+newtype Clock = Clock { unClock :: Int } deriving (Eq)
 
 addDelta :: Int -> Int -> Clock -> Clock
 addDelta h m (Clock a) = fromInt (a + h * 60 + m)


### PR DESCRIPTION
Since it's not necessary for the exercise or for testing, the `Show`
instance has been removed from the README.

Fixes #747.