### PR TITLE
pythagorean-triplet 1.0.0.3: Test only tripletsWithSum

### DIFF
--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -7,6 +7,12 @@ which,
 a**2 + b**2 = c**2
 ```
 
+and such that,
+
+```text
+a < b < c
+```
+
 For example,
 
 ```text

--- a/exercises/pythagorean-triplet/examples/success-standard/src/Triplet.hs
+++ b/exercises/pythagorean-triplet/examples/success-standard/src/Triplet.hs
@@ -1,41 +1,11 @@
-module Triplet ( Triplet, mkTriplet, pythagoreanTriplets, isPythagorean) where
-import Control.Monad.Fix (fix)
-import Data.Bits (Bits, shiftL, shiftR)
+module Triplet (tripletsWithSum) where
 
-newtype Triplet a = Triplet (a, a, a)
-                  deriving (Show, Eq)
-
-mkTriplet :: Int -> Int -> Int -> Triplet Int
-mkTriplet a b c | b < a     = mkTriplet b a c
-                | c < b     = mkTriplet a c b
-                | otherwise = Triplet (a, b, c)
-
-isPythagorean :: Triplet Int -> Bool
-isPythagorean (Triplet (a, b, c)) = square a + square b == square c
-
-square :: Integral a => a -> a
-square a = a * a
-
--- only correct for positive n >= 1
-isqrt :: (Integral a, Bits a) => a -> a
-isqrt n = go n 0 startBit
-  where
-    -- Calculate largest power of 4 that's >= n
-    startBit = fix (\f bit -> case bit `shiftL` 2 of
-                       bit' | bit' > n  -> bit
-                            | otherwise -> f bit') 1
-    go _   res 0   = res
-    go num res bit
-      | num >= resbit = go (num - resbit) (res `shiftR` 1 + bit) bit'
-      | otherwise     = go num (res `shiftR` 1) bit'
-      where resbit = res + bit
-            bit' = bit `shiftR` 2
-
-pythagoreanTriplets :: Int -> Int -> [Triplet Int]
-pythagoreanTriplets minFactor maxFactor =
-  [mkTriplet a b c
-  | a <- [minFactor..maxFactor]
-  , b <- [a..maxFactor]
-  , let c2 = square a + square b
-        c = isqrt c2
-  , c <= maxFactor && c2 == square c]
+tripletsWithSum :: Int -> [(Int, Int, Int)]
+tripletsWithSum n =
+  [ (a, b, c)
+  | a <- [1 .. n `div` 3]
+  , let b = n `div` 2 - a * n `div` (2 * (n - a))
+  , let c = n - a - b
+  , a < b
+  , a * a + b * b == c * c
+  ]

--- a/exercises/pythagorean-triplet/package.yaml
+++ b/exercises/pythagorean-triplet/package.yaml
@@ -1,5 +1,5 @@
 name: pythagorean-triplet
-version: 0.1.0.2
+version: 1.0.0.3
 
 dependencies:
   - base

--- a/exercises/pythagorean-triplet/src/Triplet.hs
+++ b/exercises/pythagorean-triplet/src/Triplet.hs
@@ -1,10 +1,4 @@
-module Triplet (isPythagorean, mkTriplet, pythagoreanTriplets) where
+module Triplet (tripletsWithSum) where
 
-isPythagorean :: (Int, Int, Int) -> Bool
-isPythagorean triplet = error "You need to implement this function."
-
-mkTriplet :: Int -> Int -> Int -> (Int, Int, Int)
-mkTriplet a b c = error "You need to implement this function."
-
-pythagoreanTriplets :: Int -> Int -> [(Int, Int, Int)]
-pythagoreanTriplets minFactor maxFactor = error "You need to implement this function."
+tripletsWithSum :: Int -> [(Int, Int, Int)]
+tripletsWithSum sum = error "You need to implement this function."

--- a/exercises/pythagorean-triplet/test/Tests.hs
+++ b/exercises/pythagorean-triplet/test/Tests.hs
@@ -1,41 +1,60 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 import Data.Foldable     (for_)
+import Data.List         (sort)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-import Triplet (isPythagorean, mkTriplet, pythagoreanTriplets)
+import Triplet (tripletsWithSum)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
 
 specs :: Spec
-specs = do
-          describe "isPythagorean"       $ for_ isPythagoreanCases       isPythagoreanTest
-          describe "pythagoreanTriplets" $ for_ pythagoreanTripletsCases pythagoreanTripletsTest
+specs = describe "pythagoreanTriplets" $ for_ cases test
   where
-
-    isPythagoreanTest ((a, b, c), expected) = it description assertion
-      where
-        description = unwords $ show <$> [a, b, c]
-        assertion   = isPythagorean (mkTriplet a b c) `shouldBe` expected
-
-    pythagoreanTripletsTest (x, y, ts) = it description assertion
-      where
-        description = unwords $ show <$> [x, y]
-        assertion   = pythagoreanTriplets x y `shouldBe` uncurry3 mkTriplet <$> ts
-
-    uncurry3 f (x, y, z) = f x y z
-
-    isPythagoreanCases = [ ( (3, 4, 5), True )
-                         , ( (3, 5, 4), True )
-                         , ( (4, 3, 5), True )
-                         , ( (4, 5, 3), True )
-                         , ( (5, 3, 4), True )
-                         , ( (5, 4, 3), True )
-                         , ( (3, 3, 3), False)
-                         , ( (5, 6, 7), False) ]
-
-    pythagoreanTripletsCases = [ (1 , 10, [ ( 3,  4,  5), ( 6,  8, 10) ])
-                               , (11, 20, [ (12, 16, 20)               ])
-                               , (56, 95, [ (57, 76, 95), (60, 63, 87) ]) ]
+    test (description, n, ts) = it description $ sort (tripletsWithSum n) `shouldBe` ts
+    cases = [ ("triplets whose sum is 12"
+              , 12
+              , [(3, 4, 5)]
+              )
+            , ("triplets whose sum is 108"
+              , 108
+              , [(27, 36, 45)]
+              )
+            , ("triplets whose sum is 1000"
+              , 1000
+              , [(200, 375, 425)]
+              )
+            , ("no matching triplets for 1001"
+              , 1001
+              , []
+              )
+            , ("returns all matching triplets"
+              , 90
+              , [ (9, 40, 41)
+                , (15, 36, 39)
+                ]
+              )
+            , ("several matching triplets"
+              , 840
+              , [ (40, 399, 401)
+                , (56, 390, 394)
+                , (105, 360, 375)
+                , (120, 350, 370)
+                , (140, 336, 364)
+                , (168, 315, 357)
+                , (210, 280, 350)
+                , (240, 252, 348)
+                ]
+              )
+            , ("triplets for large number"
+              , 30000
+              , [ (1200, 14375, 14425)
+                , (1875, 14000, 14125)
+                , (5000, 12000, 13000)
+                , (6000, 11250, 12750)
+                , (7500, 10000, 12500)
+                ]
+              )
+            ]


### PR DESCRIPTION
Replacing previous tests with isPythagorean (don't test intermediate
steps) and triplets in factor range (reasonable way to test, just not
what the canonical data chose to use)

Given the new restriction of `a < b < c` we no longer need `mkTriplet`
according to the previous rationale for keeping it (ordering):
https://github.com/exercism/haskell/pull/507#discussion_r106767328

https://github.com/exercism/problem-specifications/pull/1332
https://github.com/exercism/problem-specifications/pull/1365
