### PR TITLE
robot-simulator 3.1.0.6: Remove turnLeft and turnRight

### DIFF
--- a/exercises/robot-simulator/examples/success-standard/src/Robot.hs
+++ b/exercises/robot-simulator/examples/success-standard/src/Robot.hs
@@ -2,7 +2,7 @@ module Robot (Bearing(..),
               mkRobot,
               coordinates,
               bearing,
-              simulate,
+              move,
               turnRight,
               turnLeft
               ) where
@@ -55,5 +55,5 @@ step Advance   r = r { coordinates = advance (bearing r) (coordinates r) }
 step TurnLeft  r = r { bearing = turnLeft (bearing r) }
 step TurnRight r = r { bearing = turnRight (bearing r) }
 
-simulate :: Robot -> String -> Robot
-simulate r = foldl' (flip step) r . instructions
+move :: Robot -> String -> Robot
+move r = foldl' (flip step) r . instructions

--- a/exercises/robot-simulator/examples/success-standard/src/Robot.hs
+++ b/exercises/robot-simulator/examples/success-standard/src/Robot.hs
@@ -3,8 +3,6 @@ module Robot (Bearing(..),
               coordinates,
               bearing,
               move,
-              turnRight,
-              turnLeft
               ) where
 import Data.List (foldl')
 import Control.Arrow (first, second)

--- a/exercises/robot-simulator/package.yaml
+++ b/exercises/robot-simulator/package.yaml
@@ -1,5 +1,5 @@
 name: robot-simulator
-version: 2.2.0.5
+version: 3.1.0.6
 
 dependencies:
   - base

--- a/exercises/robot-simulator/src/Robot.hs
+++ b/exercises/robot-simulator/src/Robot.hs
@@ -4,8 +4,6 @@ module Robot
     , coordinates
     , mkRobot
     , move
-    , turnLeft
-    , turnRight
     ) where
 
 data Bearing = North
@@ -27,9 +25,3 @@ mkRobot direction coordinates = error "You need to implement this function."
 
 move :: Robot -> String -> Robot
 move robot instructions = error "You need to implement this function."
-
-turnLeft :: Bearing -> Bearing
-turnLeft direction = error "You need to implement this function."
-
-turnRight :: Bearing -> Bearing
-turnRight direction = error "You need to implement this function."

--- a/exercises/robot-simulator/src/Robot.hs
+++ b/exercises/robot-simulator/src/Robot.hs
@@ -3,7 +3,7 @@ module Robot
     , bearing
     , coordinates
     , mkRobot
-    , simulate
+    , move
     , turnLeft
     , turnRight
     ) where
@@ -25,8 +25,8 @@ coordinates robot = error "You need to implement this function."
 mkRobot :: Bearing -> (Integer, Integer) -> Robot
 mkRobot direction coordinates = error "You need to implement this function."
 
-simulate :: Robot -> String -> Robot
-simulate robot instructions = error "You need to implement this function."
+move :: Robot -> String -> Robot
+move robot instructions = error "You need to implement this function."
 
 turnLeft :: Bearing -> Bearing
 turnLeft direction = error "You need to implement this function."

--- a/exercises/robot-simulator/test/Tests.hs
+++ b/exercises/robot-simulator/test/Tests.hs
@@ -13,8 +13,6 @@ import Robot
   , coordinates
   , mkRobot
   , move
-  , turnLeft
-  , turnRight
   )
 
 main :: IO ()
@@ -38,50 +36,50 @@ specs = do
         coordinates robot `shouldBe` (-1, -1)
         bearing     robot `shouldBe` South
 
-    -- The reference tests for `turnLeft` and `turnRight` describe
-    -- functions that are applied to robots positioned at (0, 0).
-    -- In this track, they are functions over directions, so those
-    -- test cases cannot be completely implemented.
+    let turnTest inst dir dir2 =
+          let robot = mkRobot dir (0, 0) in
+          describe ("from " ++ show dir) $ do
+            it "should change direction" $
+              bearing (move robot inst) `shouldBe` dir2
+            it "shouldn't change position" $
+              coordinates (move robot inst) `shouldBe` (0, 0)
 
-    describe "turnRight" $ do
+    describe "turning right rotates the robot's direction 90 degrees clockwise" $ do
+      let rightTest = turnTest "R"
+      rightTest North East
+      rightTest East South
+      rightTest South West
+      rightTest West North
 
-      it "turn from North" $ turnRight North `shouldBe` East
-      it "turn from East"  $ turnRight East  `shouldBe` South
-      it "turn from South" $ turnRight South `shouldBe` West
-      it "turn from West"  $ turnRight West  `shouldBe` North
+    describe "turning left rotates the robot's direction 90 degrees counter-clockwise" $ do
+      let leftTest = turnTest "L"
+      leftTest North West
+      leftTest West South
+      leftTest South East
+      leftTest East North
 
-    describe "turnLeft" $ do
-
-      it "turn from North" $ turnLeft North `shouldBe` West
-      it "turn from West"  $ turnLeft West  `shouldBe` South
-      it "turn from South" $ turnLeft South `shouldBe` East
-      it "turn from East"  $ turnLeft East  `shouldBe` North
-
-    describe "move advance" $ do
-
-    -- The function described by the reference file as `advance`
-    -- doesn't exist in this track, so we test `simulate` with "A".
-
+    describe "advancing" $ do
       let dir `from` pos = move (mkRobot dir pos) "A"
+      let test desc dir pos =
+            describe (show dir ++ " from " ++ show pos) $ do
+              it "shouldn't change direction" $
+                bearing (dir `from` (0, 0)) `shouldBe` dir
+              it desc $
+                coordinates (dir `from` (0, 0)) `shouldBe` pos
 
-      it "does not change the direction" $
-        bearing (North `from` (0, 0)) `shouldBe` North
-
-      it "increases the y coordinate one when facing north" $
-        coordinates (North `from` (0, 0)) `shouldBe` (0, 1)
-
-      it "decreases the y coordinate by one when facing south" $
-        coordinates (South `from` (0, 0)) `shouldBe` (0, -1)
-
-      it "increases the x coordinate by one when facing east" $
-        coordinates (East `from` (0, 0)) `shouldBe` (1, 0)
-
-      it "decreases the x coordinate by one when facing west" $
-        coordinates (West `from` (0, 0)) `shouldBe `(-1, 0)
+      test "increases the y coordinate one when facing north" North (0, 1)
+      test "decreases the y coordinate by one when facing south" South (0, -1)
+      test "increases the x coordinate by one when facing east" East (1, 0)
+      test "decreases the x coordinate by one when facing west" West (-1, 0)
 
     describe "move" $ do
 
       let simulation pos dir = move (mkRobot dir pos)
+
+      it "instructions to move east and north from README" $ do
+        let robot = simulation (7, 3) North "RAALAL"
+        coordinates robot `shouldBe` (9, 4)
+        bearing     robot `shouldBe` West
 
       it "instructions to move west and north" $ do
         let robot = simulation (0, 0) North "LAAARALA"

--- a/exercises/robot-simulator/test/Tests.hs
+++ b/exercises/robot-simulator/test/Tests.hs
@@ -12,7 +12,7 @@ import Robot
   , bearing
   , coordinates
   , mkRobot
-  , simulate
+  , move
   , turnLeft
   , turnRight
   )
@@ -57,12 +57,12 @@ specs = do
       it "turn from South" $ turnLeft South `shouldBe` East
       it "turn from East"  $ turnLeft East  `shouldBe` North
 
-    describe "simulate advance" $ do
+    describe "move advance" $ do
 
     -- The function described by the reference file as `advance`
     -- doesn't exist in this track, so we test `simulate` with "A".
 
-      let dir `from` pos = simulate (mkRobot dir pos) "A"
+      let dir `from` pos = move (mkRobot dir pos) "A"
 
       it "does not change the direction" $
         bearing (North `from` (0, 0)) `shouldBe` North
@@ -79,12 +79,9 @@ specs = do
       it "decreases the x coordinate by one when facing west" $
         coordinates (West `from` (0, 0)) `shouldBe `(-1, 0)
 
-    describe "simulate" $ do
+    describe "move" $ do
 
-    -- The function described by the reference file as
-    -- `instructions` is called `simulate` in this track.
-
-      let simulation pos dir = simulate (mkRobot dir pos)
+      let simulation pos dir = move (mkRobot dir pos)
 
       it "instructions to move west and north" $ do
         let robot = simulation (0, 0) North "LAAARALA"


### PR DESCRIPTION
2.3.0: "Remove ambiguity" (show all parameters of the robot, even those
that don't change, which makes testing a bit of a pain)
exercism/problem-specifications#1333

3.0.0: Remove intermeditae functions, which means turnRight and turnLeft
for the Haskell track.
exercism/problem-specifications#1343

3.1.0: Renames the README case added in 3.0.0
exercism/problem-specifications#1357