### PR TITLE
bob 1.4.0.8: Make test suite compatible with `Data.Text`

### DIFF
--- a/exercises/bob/examples/success-text/package.yaml
+++ b/exercises/bob/examples/success-text/package.yaml
@@ -1,15 +1,12 @@
 name: bob
-version: 1.4.0.8
 
 dependencies:
   - base
+  - text
 
 library:
   exposed-modules: Bob
   source-dirs: src
-  # dependencies:
-  # - foo       # List here the packages you
-  # - bar       # want to use in your solution.
 
 tests:
   test:

--- a/exercises/bob/examples/success-text/src/Bob.hs
+++ b/exercises/bob/examples/success-text/src/Bob.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Bob (responseFor) where
+
+import Data.Char (isSpace, isUpper, isLower)
+import qualified Data.Text as T
+import           Data.Text (Text)
+
+responseFor :: Text -> Text
+responseFor s
+  | isSilent s = "Fine. Be that way!"
+  | isYelling s && isAsking s = "Calm down, I know what I'm doing!"
+  | isYelling s = "Whoa, chill out!"
+  | isAsking s = "Sure."
+  | otherwise = "Whatever."
+
+isSilent, isYelling, isAsking :: Text -> Bool
+isSilent = T.all isSpace
+isYelling = (&&) <$> T.any isUpper <*> T.all (not . isLower)
+isAsking = (Just '?' ==) . fmap snd . T.unsnoc . T.stripEnd

--- a/exercises/bob/test/Tests.hs
+++ b/exercises/bob/test/Tests.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Data.String       (fromString)
 
 import Bob (responseFor)
 
@@ -12,7 +14,7 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = describe "responseFor" $ for_ cases test
   where
-    test Case{..} = it description $ responseFor input `shouldBe` expected
+    test Case{..} = it description $ responseFor (fromString input) `shouldBe` fromString expected
 
 data Case = Case { description :: String
                  , input       :: String


### PR DESCRIPTION
The only thing that is necessary for the test suite to support a

    responseFor :: Text -> Text

is to assume that it has the type `IsString s => s -> s`.

We leave the stub as `String -> String`, but make the test suite compatible with the change. This means that mentors can suggest a solution based on `Data.Text` if they like. One case where that might make sense is when they refer to `Data.Text.strip`.

A `Data.Text`-based solution is provided as an example.

Exercise version bumped from 1.4.0.7 to 1.4.0.8.