### PR TITLE
rna-transcription: Change from 'Maybe' to 'Either Char'

### DIFF
--- a/config.json
+++ b/config.json
@@ -75,7 +75,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "maybe"
+        "either"
       ]
     },
     {

--- a/exercises/rna-transcription/examples/success-standard/src/DNA.hs
+++ b/exercises/rna-transcription/examples/success-standard/src/DNA.hs
@@ -1,12 +1,11 @@
 module DNA (toRNA) where
 
-import qualified Data.Map.Strict as Map
-
-toRNA :: String -> Maybe String
-toRNA = mapM (`Map.lookup` rna)
+toRNA :: String -> Either Char String
+toRNA = mapM fromDNA
   where
-    rna = Map.fromList [ ('C', 'G')
-                       , ('G', 'C')
-                       , ('A', 'U')
-                       , ('T', 'A') ]
-
+    fromDNA :: Char -> Either Char Char
+    fromDNA 'C' = return 'G'
+    fromDNA 'G' = return 'C'
+    fromDNA 'A' = return 'U'
+    fromDNA 'T' = return 'A'
+    fromDNA  c  = Left c

--- a/exercises/rna-transcription/package.yaml
+++ b/exercises/rna-transcription/package.yaml
@@ -1,5 +1,5 @@
 name: rna-transcription
-version: 1.3.0.8
+version: 1.3.0.9
 
 dependencies:
   - base

--- a/exercises/rna-transcription/src/DNA.hs
+++ b/exercises/rna-transcription/src/DNA.hs
@@ -1,4 +1,4 @@
 module DNA (toRNA) where
 
-toRNA :: String -> Maybe String
+toRNA :: String -> Either Char String
 toRNA xs = error "You need to implement this function."

--- a/exercises/rna-transcription/test/Tests.hs
+++ b/exercises/rna-transcription/test/Tests.hs
@@ -14,46 +14,46 @@ specs = describe "toRNA" $ for_ cases test
   where
     test Case{..} = it description $ toRNA dna `shouldBe` expected
 
-data Case = Case { description ::       String
-                 , dna         ::       String
-                 , expected    :: Maybe String
+data Case = Case { description :: String
+                 , dna         :: String
+                 , expected    :: Either Char String
                  }
 
 cases :: [Case]
 cases = [ Case { description = "Empty RNA sequence"
-               , dna         =      ""
-               , expected    = Just ""
+               , dna         = ""
+               , expected    = Right ""
                }
         , Case { description = "RNA complement of cytosine is guanine"
-               , dna         =      "C"
-               , expected    = Just "G"
+               , dna         = "C"
+               , expected    = Right "G"
                }
         , Case { description = "RNA complement of guanine is cytosine"
-               , dna         =      "G"
-               , expected    = Just "C"
+               , dna         = "G"
+               , expected    = Right "C"
                }
         , Case { description = "RNA complement of thymine is adenine"
-               , dna         =      "T"
-               , expected    = Just "A"
+               , dna         = "T"
+               , expected    = Right "A"
                }
         , Case { description = "RNA complement of adenine is uracil"
-               , dna         =      "A"
-               , expected    = Just "U"
+               , dna         = "A"
+               , expected    = Right "U"
                }
         , Case { description = "RNA complement"
-               , dna         =      "ACGTGGTCTTAA"
-               , expected    = Just "UGCACCAGAAUU"
+               , dna         = "ACGTGGTCTTAA"
+               , expected    = Right "UGCACCAGAAUU"
                }
         , Case { description = "correctly handles invalid input (RNA instead of DNA)"
                , dna         = "U"
-               , expected    = Nothing
+               , expected    = Left 'U'
                }
         , Case { description = "correctly handles completely invalid DNA input"
                , dna         = "XXX"
-               , expected    = Nothing
+               , expected    = Left 'X'
                }
         , Case { description = "correctly handles partially invalid DNA input"
                , dna         = "ACGTXXXCTTAA"
-               , expected    = Nothing
+               , expected    = Left 'X'
                }
         ]


### PR DESCRIPTION
Since `RNA Transcription` is currently the second core exercise that uses error-aware return types, it would make sense to practice `Either` as an alternative to `Maybe`.

This suggestion came as a consequence of the discussion in #761.