### PR TITLE
docs: rm headings from LEARNING and RESOURCES

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,5 +1,3 @@
-## Learning Haskell
-
 Haskell is a purely functional language, which is a paradigm fundamentally different than the more
 commonly taught [object oriented approach](https://en.wikipedia.org/wiki/Object-oriented_programming). Because of this,
 learning Haskell can feel different than simply picking up another language.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,5 +1,3 @@
-## Recommended Learning Resources
-
 * The [#haskell](http://webchat.freenode.net/?channels=haskell) IRC channel on irc.freenode.net whose goal is to "encourage learning and discussion of Haskell, functional programming, and programming in general". More information about the IRC channel can be found on [the Haskell Wiki page for the channel](https://wiki.haskell.org/IRC_channel).
 * [Hoogle](https://www.haskell.org/hoogle/) is a Haskell API search engine. This allows you to look up what a function does if all you know is its name. Perhaps more interestingly, it also supports searching by type signature: If you want to know what functions have the type signature [(a -> b) -> [a] -> [b]](https://www.haskell.org/hoogle/?hoogle=%28a+-%3E+b%29+-%3E+[a]+-%3E+[b]), Hoogle helps you find out!
 * [Stack Overflow](http://stackoverflow.com/questions/tagged/haskell) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.


### PR DESCRIPTION
These are used in the following:
https://exercism.io/tracks/haskell/learning
https://exercism.io/tracks/haskell/resources

There is a nice page header on those pages that say "Learning Haskell"
and "Useful Haskell Resources" respectively, making our headers
unnecessary.

Particularly useful because the previous header of RESOURCES was
"Recommended Learning Resources" which is against the purpose of
RESOURCES as stated in:

https://github.com/exercism/docs/blob/master/language-tracks/documentation/for-consumers.md#file-structure
https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md#improve-product-facing-copydocumentation