### PR TITLE
minesweeper: switch y and x coordinates

### DIFF
--- a/exercises/minesweeper/src/Example.hs
+++ b/exercises/minesweeper/src/Example.hs
@@ -4,7 +4,7 @@ import Data.Char (intToDigit)
 import Data.Array (listArray, (!))
 
 annotate :: [String] -> [String]
-annotate board = [[ out (x, y) | x <- [1 .. xn]] | y <- [1 .. yn]]
+annotate board = [[ out (y, x) | x <- [1 .. xn]] | y <- [1 .. yn]]
   where
     yn = length board
     -- assume rectangular input
@@ -16,9 +16,9 @@ annotate board = [[ out (x, y) | x <- [1 .. xn]] | y <- [1 .. yn]]
     showMineCount 0 = ' '
     showMineCount i = intToDigit i
     isMine = ('*' ==)
-    mines = listArray ((1, 1), (xn, yn)) (map isMine (concat board))
-    neighbors (x, y) =
-      [ fromEnum (mines ! (x', y'))
+    mines = listArray ((1, 1), (yn, xn)) (map isMine (concat board))
+    neighbors (y, x) =
+      [ fromEnum (mines ! (y', x'))
       | y' <- [max 1 (y - 1) .. min yn (y + 1)]
       , x' <- [max 1 (x - 1) .. min xn (x + 1)]
       , x' /= x || y' /= y


### PR DESCRIPTION
Otherwise, the example solution fails on any board that meets both
conditions:

* both dimensions larger than 1
* not symmetric on the diagonal formed by `(n, n)` forall n

For the test data used in the only such board is "large board"

To see why, see that `listArray (1, 1) (X, Y)` assigns indices to
elements in the order `(1, 1), (1, 2) ... (1, Y), (2, 1) ...`
However, we `concat` the `[String]` board, which means that successive
elements should increment the X coordinate, not the Y coordinate.
By switching X and Y in `listArray` (and all other uses), we get a
correct assignment.

Note that it's necessary for both dimensions to be larger than 1. If
either dimension is 1, only one of the dimensions gets increased in
`listArray`, therefore there is no danger of an incorrect assignment.

Solving the mystery of
https://github.com/exercism/haskell/pull/284