### PR TITLE
Add -Wall to all package.yaml

### DIFF
--- a/exercises/accumulate/package.yaml
+++ b/exercises/accumulate/package.yaml
@@ -1,5 +1,5 @@
 name: accumulate
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Accumulate
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/acronym/package.yaml
+++ b/exercises/acronym/package.yaml
@@ -1,5 +1,5 @@
 name: acronym
-version: 1.6.0.8
+version: 1.6.0.9
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Acronym
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/all-your-base/package.yaml
+++ b/exercises/all-your-base/package.yaml
@@ -1,5 +1,5 @@
 name: all-your-base
-version: 2.3.0.7
+version: 2.3.0.8
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Base
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/allergies/package.yaml
+++ b/exercises/allergies/package.yaml
@@ -1,5 +1,5 @@
 name: allergies
-version: 1.2.0.6
+version: 1.2.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Allergies
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/alphametics/package.yaml
+++ b/exercises/alphametics/package.yaml
@@ -1,5 +1,5 @@
 name: alphametics
-version: 1.3.0.5
+version: 1.3.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Alphametics
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/anagram/package.yaml
+++ b/exercises/anagram/package.yaml
@@ -1,5 +1,5 @@
 name: anagram
-version: 1.4.0.7
+version: 1.4.0.8
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Anagram
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/armstrong-numbers/package.yaml
+++ b/exercises/armstrong-numbers/package.yaml
@@ -1,5 +1,5 @@
 name: armstrong-numbers
-version: 1.0.0.1
+version: 1.0.0.2
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: ArmstrongNumbers
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/atbash-cipher/package.yaml
+++ b/exercises/atbash-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: atbash-cipher
-version: 1.2.0.5
+version: 1.2.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Atbash
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/bank-account/package.yaml
+++ b/exercises/bank-account/package.yaml
@@ -1,5 +1,5 @@
 name: bank-account
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: BankAccount
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/beer-song/package.yaml
+++ b/exercises/beer-song/package.yaml
@@ -1,5 +1,5 @@
 name: beer-song
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Beer
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/binary-search-tree/package.yaml
+++ b/exercises/binary-search-tree/package.yaml
@@ -1,5 +1,5 @@
 name: binary-search-tree
-version: 1.0.0.3
+version: 1.0.0.4
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: BST
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/binary/package.yaml
+++ b/exercises/binary/package.yaml
@@ -1,5 +1,5 @@
 name: binary
-version: 0.9.0.2
+version: 0.9.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Binary
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/binary/package.yaml
+++ b/exercises/binary/package.yaml
@@ -1,5 +1,5 @@
 name: binary
-version: 0.9.0.2 # 2016-07-26
+version: 0.9.0.2
 
 dependencies:
   - base

--- a/exercises/bob/package.yaml
+++ b/exercises/bob/package.yaml
@@ -1,5 +1,5 @@
 name: bob
-version: 1.4.0.8
+version: 1.4.0.9
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Bob
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/bowling/package.yaml
+++ b/exercises/bowling/package.yaml
@@ -1,5 +1,5 @@
 name: bowling
-version: 1.2.0.6
+version: 1.2.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Bowling
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/bracket-push/package.yaml
+++ b/exercises/bracket-push/package.yaml
@@ -1,5 +1,5 @@
 name: bracket-push
-version: 1.5.0.6
+version: 1.5.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Brackets
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/change/package.yaml
+++ b/exercises/change/package.yaml
@@ -1,5 +1,5 @@
 name: change
-version: 1.3.0.6
+version: 1.3.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Change
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/clock/package.yaml
+++ b/exercises/clock/package.yaml
@@ -1,5 +1,5 @@
 name: exercism-clock
-version: 2.3.0.7
+version: 2.3.0.8
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Clock
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/collatz-conjecture/package.yaml
+++ b/exercises/collatz-conjecture/package.yaml
@@ -1,5 +1,5 @@
 name: collatz-conjecture
-version: 1.2.1.3
+version: 1.2.1.4
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: CollatzConjecture
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/complex-numbers/package.yaml
+++ b/exercises/complex-numbers/package.yaml
@@ -1,5 +1,5 @@
 name: complex-numbers
-version: 1.3.0.4
+version: 1.3.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: ComplexNumbers
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/connect/package.yaml
+++ b/exercises/connect/package.yaml
@@ -1,5 +1,5 @@
 name: connect
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Connect
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/crypto-square/package.yaml
+++ b/exercises/crypto-square/package.yaml
@@ -1,5 +1,5 @@
 name: crypto-square
-version: 3.2.0.5
+version: 3.2.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: CryptoSquare
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/custom-set/package.yaml
+++ b/exercises/custom-set/package.yaml
@@ -1,5 +1,5 @@
 name: custom-set
-version: 1.3.0.5
+version: 1.3.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: CustomSet
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/diamond/package.yaml
+++ b/exercises/diamond/package.yaml
@@ -1,5 +1,5 @@
 name: diamond
-version: 1.1.0.3
+version: 1.1.0.4
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Diamond
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/difference-of-squares/package.yaml
+++ b/exercises/difference-of-squares/package.yaml
@@ -1,5 +1,5 @@
 name: difference-of-squares
-version: 1.2.0.6
+version: 1.2.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Squares
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/dominoes/package.yaml
+++ b/exercises/dominoes/package.yaml
@@ -1,5 +1,5 @@
 name: dominoes
-version: 2.1.0.6
+version: 2.1.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Dominoes
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/etl/package.yaml
+++ b/exercises/etl/package.yaml
@@ -1,5 +1,5 @@
 name: etl
-version: 1.0.0.3
+version: 1.0.0.4
 
 dependencies:
   - base
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: ETL
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/food-chain/package.yaml
+++ b/exercises/food-chain/package.yaml
@@ -1,5 +1,5 @@
 name: food-chain
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: FoodChain
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/forth/package.yaml
+++ b/exercises/forth/package.yaml
@@ -1,5 +1,5 @@
 name: forth
-version: 1.7.0.10
+version: 1.7.0.11
 
 dependencies:
   - base
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: Forth
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/gigasecond/package.yaml
+++ b/exercises/gigasecond/package.yaml
@@ -1,5 +1,5 @@
 name: gigasecond
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: Gigasecond
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/go-counting/package.yaml
+++ b/exercises/go-counting/package.yaml
@@ -1,5 +1,5 @@
 name: go-counting
-version: 1.0.0.3
+version: 1.0.0.4
 
 dependencies:
   - base
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: Counting
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/grade-school/package.yaml
+++ b/exercises/grade-school/package.yaml
@@ -1,5 +1,5 @@
 name: grade-school
-version: 1.0.0.3
+version: 1.0.0.4
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: School
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/grains/package.yaml
+++ b/exercises/grains/package.yaml
@@ -1,5 +1,5 @@
 name: grains
-version: 1.2.0.5
+version: 1.2.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Grains
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/hamming/package.yaml
+++ b/exercises/hamming/package.yaml
@@ -1,5 +1,5 @@
 name: hamming
-version: 2.1.1.7
+version: 2.1.1.8
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Hamming
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/hello-world/package.yaml
+++ b/exercises/hello-world/package.yaml
@@ -1,5 +1,5 @@
 name: hello-world
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: HelloWorld
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/hexadecimal/package.yaml
+++ b/exercises/hexadecimal/package.yaml
@@ -1,5 +1,5 @@
 name: hexadecimal
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Hexadecimal
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/house/package.yaml
+++ b/exercises/house/package.yaml
@@ -1,5 +1,5 @@
 name: house
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: House
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/isbn-verifier/package.yaml
+++ b/exercises/isbn-verifier/package.yaml
@@ -1,5 +1,5 @@
 name: isbn-verifier
-version: 2.7.0.8
+version: 2.7.0.9
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: IsbnVerifier
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/isogram/package.yaml
+++ b/exercises/isogram/package.yaml
@@ -1,5 +1,5 @@
 name: isogram
-version: 1.7.0.6
+version: 1.7.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Isogram
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/kindergarten-garden/package.yaml
+++ b/exercises/kindergarten-garden/package.yaml
@@ -1,5 +1,5 @@
 name: kindergarten-garden
-version: 1.1.1.7
+version: 1.1.1.8
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Garden
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/largest-series-product/package.yaml
+++ b/exercises/largest-series-product/package.yaml
@@ -1,5 +1,5 @@
 name: largest-series-product
-version: 1.2.0.5
+version: 1.2.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Series
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/leap/package.yaml
+++ b/exercises/leap/package.yaml
@@ -1,5 +1,5 @@
 name: leap
-version: 1.4.0.7
+version: 1.4.0.8
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: LeapYear
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/lens-person/package.yaml
+++ b/exercises/lens-person/package.yaml
@@ -1,5 +1,5 @@
 name: lens-person
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: Person
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/linked-list/package.yaml
+++ b/exercises/linked-list/package.yaml
@@ -1,5 +1,5 @@
 name: linked-list
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Deque
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/list-ops/package.yaml
+++ b/exercises/list-ops/package.yaml
@@ -1,5 +1,5 @@
 name: list-ops
-version: 2.3.0.6
+version: 2.3.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: ListOps
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/luhn/package.yaml
+++ b/exercises/luhn/package.yaml
@@ -1,5 +1,5 @@
 name: luhn
-version: 1.3.0.5
+version: 1.3.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Luhn
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/matrix/package.yaml
+++ b/exercises/matrix/package.yaml
@@ -1,5 +1,5 @@
 name: matrix
-version: 1.0.0.5
+version: 1.0.0.6
 
 dependencies:
   - base
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: Matrix
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/meetup/package.yaml
+++ b/exercises/meetup/package.yaml
@@ -1,5 +1,5 @@
 name: meetup
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: Meetup
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/minesweeper/package.yaml
+++ b/exercises/minesweeper/package.yaml
@@ -1,5 +1,5 @@
 name: minesweeper
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Minesweeper
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/nth-prime/package.yaml
+++ b/exercises/nth-prime/package.yaml
@@ -1,5 +1,5 @@
 name: nth-prime
-version: 2.1.0.5
+version: 2.1.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Prime
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/nucleotide-count/package.yaml
+++ b/exercises/nucleotide-count/package.yaml
@@ -1,5 +1,5 @@
 name: nucleotide-count
-version: 1.3.0.6
+version: 1.3.0.7
 
 dependencies:
   - base
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: DNA
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/ocr-numbers/package.yaml
+++ b/exercises/ocr-numbers/package.yaml
@@ -1,5 +1,5 @@
 name: ocr-numbers
-version: 1.2.0.5
+version: 1.2.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: OCR
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/octal/package.yaml
+++ b/exercises/octal/package.yaml
@@ -1,5 +1,5 @@
 name: octal
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Octal
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/palindrome-products/package.yaml
+++ b/exercises/palindrome-products/package.yaml
@@ -1,5 +1,5 @@
 name: palindrome-products
-version: 1.1.0.3
+version: 1.1.0.4
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Palindromes
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/pangram/package.yaml
+++ b/exercises/pangram/package.yaml
@@ -1,5 +1,5 @@
 name: pangram
-version: 1.4.1.7
+version: 1.4.1.8
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Pangram
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/parallel-letter-frequency/package.yaml
+++ b/exercises/parallel-letter-frequency/package.yaml
@@ -1,5 +1,5 @@
 name: parallel-letter-frequency
-version: 0.1.0.3
+version: 0.1.0.4
 
 dependencies:
   - base
@@ -9,6 +9,7 @@ dependencies:
 library:
   exposed-modules: Frequency
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/pascals-triangle/package.yaml
+++ b/exercises/pascals-triangle/package.yaml
@@ -1,5 +1,5 @@
 name: pascals-triangle
-version: 1.5.0.8
+version: 1.5.0.9
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Triangle
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/perfect-numbers/package.yaml
+++ b/exercises/perfect-numbers/package.yaml
@@ -1,5 +1,5 @@
 name: perfect-numbers
-version: 1.1.0.3
+version: 1.1.0.4
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: PerfectNumbers
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/phone-number/package.yaml
+++ b/exercises/phone-number/package.yaml
@@ -1,5 +1,5 @@
 name: phone-number
-version: 1.6.1.7
+version: 1.6.1.8
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Phone
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/pig-latin/package.yaml
+++ b/exercises/pig-latin/package.yaml
@@ -1,5 +1,5 @@
 name: pig-latin
-version: 1.2.0.5
+version: 1.2.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: PigLatin
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/poker/package.yaml
+++ b/exercises/poker/package.yaml
@@ -1,5 +1,5 @@
 name: poker
-version: 1.1.0.1
+version: 1.1.0.2
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Poker
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/pov/package.yaml
+++ b/exercises/pov/package.yaml
@@ -1,5 +1,5 @@
 name: pov
-version: 1.3.0.6
+version: 1.3.0.7
 
 dependencies:
   - base
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: POV
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/prime-factors/package.yaml
+++ b/exercises/prime-factors/package.yaml
@@ -1,5 +1,5 @@
 name: prime-factors
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: PrimeFactors
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/protein-translation/package.yaml
+++ b/exercises/protein-translation/package.yaml
@@ -1,5 +1,5 @@
 name: protein-translation
-version: 1.1.1.2
+version: 1.1.1.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: ProteinTranslation
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/proverb/package.yaml
+++ b/exercises/proverb/package.yaml
@@ -1,5 +1,5 @@
 name: proverb
-version: 1.1.0.1
+version: 1.1.0.2
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Proverb
   source-dirs: src
+  ghc-options: -Wall
 
 tests:
   test:

--- a/exercises/pythagorean-triplet/package.yaml
+++ b/exercises/pythagorean-triplet/package.yaml
@@ -1,5 +1,5 @@
 name: pythagorean-triplet
-version: 1.0.0.3
+version: 1.0.0.4
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Triplet
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/queen-attack/package.yaml
+++ b/exercises/queen-attack/package.yaml
@@ -1,5 +1,5 @@
 name: queen-attack
-version: 2.2.0.6
+version: 2.2.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Queens
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/rail-fence-cipher/package.yaml
+++ b/exercises/rail-fence-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: rail-fence-cipher
-version: 1.1.0.3
+version: 1.1.0.4
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: RailFenceCipher
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/raindrops/package.yaml
+++ b/exercises/raindrops/package.yaml
@@ -1,5 +1,5 @@
 name: raindrops
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Raindrops
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/rna-transcription/package.yaml
+++ b/exercises/rna-transcription/package.yaml
@@ -1,5 +1,5 @@
 name: rna-transcription
-version: 1.3.0.9
+version: 1.3.0.10
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: DNA
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/robot-name/package.yaml
+++ b/exercises/robot-name/package.yaml
@@ -1,5 +1,5 @@
 name: robot-name
-version: 0.1.0.3
+version: 0.1.0.4
 
 dependencies:
   - base
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: Robot
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/robot-simulator/package.yaml
+++ b/exercises/robot-simulator/package.yaml
@@ -1,5 +1,5 @@
 name: robot-simulator
-version: 3.1.0.6
+version: 3.1.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Robot
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/roman-numerals/package.yaml
+++ b/exercises/roman-numerals/package.yaml
@@ -1,5 +1,5 @@
 name: roman-numerals
-version: 1.2.0.5
+version: 1.2.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Roman
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/rotational-cipher/package.yaml
+++ b/exercises/rotational-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: rotational-cipher
-version: 1.2.0.2
+version: 1.2.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: RotationalCipher
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/run-length-encoding/package.yaml
+++ b/exercises/run-length-encoding/package.yaml
@@ -1,5 +1,5 @@
 name: run-length-encoding
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: RunLength
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/saddle-points/package.yaml
+++ b/exercises/saddle-points/package.yaml
@@ -1,5 +1,5 @@
 name: saddle-points
-version: 1.3.0.6
+version: 1.3.0.7
 
 dependencies:
   - array
@@ -8,6 +8,7 @@ dependencies:
 library:
   exposed-modules: Matrix
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/say/package.yaml
+++ b/exercises/say/package.yaml
@@ -1,5 +1,5 @@
 name: say
-version: 1.2.0.5
+version: 1.2.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Say
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/scrabble-score/package.yaml
+++ b/exercises/scrabble-score/package.yaml
@@ -1,5 +1,5 @@
 name: scrabble-score
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Scrabble
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/secret-handshake/package.yaml
+++ b/exercises/secret-handshake/package.yaml
@@ -1,5 +1,5 @@
 name: secret-handshake
-version: 1.2.0.5
+version: 1.2.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: SecretHandshake
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/series/package.yaml
+++ b/exercises/series/package.yaml
@@ -1,5 +1,5 @@
 name: series
-version: 1.0.0.3
+version: 1.0.0.4
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Series
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/sgf-parsing/package.yaml
+++ b/exercises/sgf-parsing/package.yaml
@@ -1,5 +1,5 @@
 name: sgf-parsing
-version: 1.0.0.3
+version: 1.0.0.4
 
 dependencies:
   - base
@@ -9,6 +9,7 @@ dependencies:
 library:
   exposed-modules: Sgf
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/sieve/package.yaml
+++ b/exercises/sieve/package.yaml
@@ -1,5 +1,5 @@
 name: sieve
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Sieve
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/simple-cipher/package.yaml
+++ b/exercises/simple-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: simple-cipher
-version: 1.2.0.4
+version: 1.2.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Cipher
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/simple-linked-list/package.yaml
+++ b/exercises/simple-linked-list/package.yaml
@@ -1,5 +1,5 @@
 name: simple-linked-list
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: LinkedList
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/space-age/package.yaml
+++ b/exercises/space-age/package.yaml
@@ -1,5 +1,5 @@
 name: space-age
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: SpaceAge
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/spiral-matrix/package.yaml
+++ b/exercises/spiral-matrix/package.yaml
@@ -1,5 +1,5 @@
 name: spiral-matrix
-version: 1.1.0.2
+version: 1.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Spiral
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/strain/package.yaml
+++ b/exercises/strain/package.yaml
@@ -1,5 +1,5 @@
 name: strain
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Strain
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/sublist/package.yaml
+++ b/exercises/sublist/package.yaml
@@ -1,5 +1,5 @@
 name: sublist
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Sublist
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/sum-of-multiples/package.yaml
+++ b/exercises/sum-of-multiples/package.yaml
@@ -1,5 +1,5 @@
 name: sum-of-multiples
-version: 1.5.0.9
+version: 1.5.0.10
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: SumOfMultiples
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/transpose/package.yaml
+++ b/exercises/transpose/package.yaml
@@ -1,5 +1,5 @@
 name: transpose
-version: 1.1.0.1
+version: 1.1.0.2
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Transpose
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/triangle/package.yaml
+++ b/exercises/triangle/package.yaml
@@ -1,5 +1,5 @@
 name: triangle
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Triangle
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/trinary/package.yaml
+++ b/exercises/trinary/package.yaml
@@ -1,5 +1,5 @@
 name: trinary
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Trinary
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/twelve-days/package.yaml
+++ b/exercises/twelve-days/package.yaml
@@ -1,5 +1,5 @@
 name: twelve-days
-version: 1.2.0.3
+version: 1.2.0.4
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: TwelveDays
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/word-count/package.yaml
+++ b/exercises/word-count/package.yaml
@@ -1,5 +1,5 @@
 name: word-count
-version: 1.2.0.5
+version: 1.2.0.6
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: WordCount
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/wordy/package.yaml
+++ b/exercises/wordy/package.yaml
@@ -1,5 +1,5 @@
 name: wordy
-version: 1.4.0.6
+version: 1.4.0.7
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: WordProblem
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/zebra-puzzle/package.yaml
+++ b/exercises/zebra-puzzle/package.yaml
@@ -1,5 +1,5 @@
 name: zebra-puzzle
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: ZebraPuzzle
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.

--- a/exercises/zipper/package.yaml
+++ b/exercises/zipper/package.yaml
@@ -1,5 +1,5 @@
 name: zipper
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -7,6 +7,7 @@ dependencies:
 library:
   exposed-modules: Zipper
   source-dirs: src
+  ghc-options: -Wall
   # dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.


### PR DESCRIPTION
I added `ghc-options: -Wall` below `source-dirs: src` 

    library:
      ...
      source-dirs: src
      ghc-options: -Wall

for both example solutions and exercise stubs, using the following command:

    find . -name package.yaml -exec perl -i -pe 's/(source-dirs: src)/$1\n  ghc-options: -Wall/s' {} \;

This causes warnings to show on both `stack build` and `stack test`.

I realize that version numbers should be bumped, too. Oh dear.