### PR TITLE
WIP: hamming: Add generator/shrinker to property-based tests

### DIFF
--- a/exercises/hamming/examples/success-standard/package.yaml
+++ b/exercises/hamming/examples/success-standard/package.yaml
@@ -14,3 +14,4 @@ tests:
     dependencies:
       - hamming
       - hspec
+      - QuickCheck

--- a/exercises/hamming/package.yaml
+++ b/exercises/hamming/package.yaml
@@ -19,3 +19,4 @@ tests:
     dependencies:
       - hamming
       - hspec
+      - QuickCheck

--- a/exercises/hamming/test/Tests.hs
+++ b/exercises/hamming/test/Tests.hs
@@ -4,26 +4,33 @@
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Data.List         ((\\))
+import Data.Ord          (comparing)
+import Test.QuickCheck
 
 import Hamming (distance)
+
+instance Arbitrary Case where
+  arbitrary = sized hammingGen
+  shrink = hammingShrink
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
 
 specs :: Spec
-specs = describe "distance" $ for_ cases test
+specs = describe "distance" $ do
+  for_ cases test
+  it "works in general" (property test')
   where
-
-    test Case{..} = it description assertion
-      where
-        assertion  = expression `shouldBe` fromIntegral <$> expected
-        expression = distance strand1 strand2
+    test Case{..} = it description (distance strand1 strand2 `shouldBe` (fromIntegral <$> expected))
+    test' Case{..} = distance strand1 strand2 === (fromIntegral <$> expected)
 
 data Case = Case { description :: String
                  , strand1     :: String
                  , strand2     :: String
                  , expected    :: Maybe Integer
                  }
+            deriving (Show, Eq)
 
 cases :: [Case]
 cases = [ Case { description = "empty strands"
@@ -102,3 +109,65 @@ cases = [ Case { description = "empty strands"
                , expected    = Nothing
                }
         ]
+
+hammingGen :: Int -> Gen Case
+hammingGen 0 = return
+  Case { description = "Empty strands have no distance"
+       , strand1 = ""
+       , strand2 = ""
+       , expected = Just 0
+       }
+
+hammingGen n = do
+  (a, b, count) <- nucleotidePairGen
+  case' <- hammingGen (n-1)
+  return . hammingDesc $
+    case' { description = ""
+          , strand1 = a ++ strand1 case'
+          , strand2 = b ++ strand2 case'
+          , expected = (+) <$> count <*> expected case'
+          }
+
+hammingDesc :: Case -> Case
+hammingDesc case'@Case{..} = case' { description = desc' }
+  where
+    desc' = "Strands of " ++ length' ++ " with " ++ dist' ++ " distance"
+    dist' = maybe "invalid" show expected
+    length' = case comparing length strand1 strand2 of
+      EQ -> "lengths " ++ show (length strand1)
+      _  -> "different lengths " ++ show (length strand1) ++ " and " ++
+            show (length strand2)
+
+nucleotidePairGen :: Gen (String, String, Maybe Integer)
+nucleotidePairGen = frequency
+  [ (20, zeroDistance)
+  , (4, oneDistance)
+  , (1, invalidDistance)
+  ]
+  where
+    zeroDistance = do
+      a <- elements "ACGT"
+      return ([a], [a], Just 0)
+
+    oneDistance = do
+      a <- elements "ACGT"
+      b <- elements ("ACGT" \\ [a])
+      return ([a], [b], Just 1)
+
+    invalidDistance = do
+      a <- elements "ACGT"
+      return ([a], [], Nothing)
+
+-- | `select [1,2,3]` = `[(1,[2,3]),(2,[1,3]),(3,[1,2])]`.
+select :: [a] -> [(a, [a])]
+select [] = []
+select (x:xs) = (x, xs) : map (fmap (x:)) (select xs)
+
+hammingShrink :: Case -> [Case]
+hammingShrink case'@Case{..} = map hammingDesc $
+  zipWith shrink' (select strand1) (select strand2)
+  where
+    shrink' (a, strand1') (b, strand2') =
+      case' { strand1 = strand1'
+            , strand2 = strand2'
+            , expected = (if a == b then id else pred) <$> expected }


### PR DESCRIPTION
The essential properties are already being tested:

 - Strands with different lengths have no distance.
 - Strands with same lengths and two nucleotides in the
   same position that are different, have one more length.

The generator adds three cases for nucleotides:

 - Same nucleotide => same length.
 - Different nucleotides => +1 length.
 - Missing nucleotide => no length.

`shrink` produces all combinations of removing nucleotides pairwise:

 - Same nucleotide => same length.
 - Different nucleotides => -1 length.

For missing nucleotides, `shrink` relies on `expected = Nothing`.