### PR TITLE
wordy 1.5.0.8: Test question `What is?` with no operands or operators

### DIFF
--- a/exercises/wordy/package.yaml
+++ b/exercises/wordy/package.yaml
@@ -1,5 +1,5 @@
 name: wordy
-version: 1.4.0.7
+version: 1.5.0.8
 
 dependencies:
   - base

--- a/exercises/wordy/test/Tests.hs
+++ b/exercises/wordy/test/Tests.hs
@@ -92,8 +92,12 @@ cases = [ Case { description = "just a number"
                , input       = "Who is the President of the United States?"
                , expected    = Nothing
                }
-        , Case { description = "reject incomplete problem"
+        , Case { description = "reject problem missing an operand"
                , input       = "What is 1 plus?"
+               , expected    = Nothing
+               }
+        , Case { description = "reject problem with no operands or operators"
+               , input       = "What is?"
                , expected    = Nothing
                }
         , Case { description = "reject two operations in a row"


### PR DESCRIPTION
In keeping with [1.3.0][], we want to test that this fails in an
expected way rather than an unexpected way.

[1.3.0]: https://github.com/exercism/problem-specifications/pull/1383

Specifically for Haskell, we want to make sure that this results in
`None` rather than accessing an out-of-bounds index due to always
assuming that the inputs will have at least three space-separated
elements (of the form "What is X...?").

https://github.com/exercism/problem-specifications/pull/1401