### PR TITLE
WIP: Make Pangram based on `Data.Text`

### DIFF
--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -8,6 +8,12 @@ The best known English pangram is:
 The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
 insensitive. Input will not contain non-ASCII symbols.
 
+## Hints
+
+Haskell has many string types with `String` being the default. This exercise,
+however, asks that you explore the type `Text` instead. You can read more about
+[string types](https://haskell-lang.org/tutorial/string-types) and explore the
+[`Data.Text` library](https://hackage.haskell.org/package/text-1.2.3.1/docs/Data-Text.html).
 
 ## Getting Started
 

--- a/exercises/pangram/examples/success-text/package.yaml
+++ b/exercises/pangram/examples/success-text/package.yaml
@@ -1,16 +1,13 @@
 name: pangram
-version: 1.4.1.9
 
 dependencies:
   - base
+  - text
+  - containers
 
 library:
   exposed-modules: Pangram
   source-dirs: src
-  ghc-options: -Wall
-  # dependencies:
-  # - foo       # List here the packages you
-  # - bar       # want to use in your solution.
 
 tests:
   test:

--- a/exercises/pangram/examples/success-text/src/Pangram.hs
+++ b/exercises/pangram/examples/success-text/src/Pangram.hs
@@ -1,0 +1,13 @@
+module Pangram (isPangram) where
+
+import qualified Data.Set as S
+import           Data.Set (Set)
+
+import qualified Data.Text as T
+import           Data.Text (Text)
+
+isPangram :: Text -> Bool
+isPangram = S.null . T.foldl' (flip S.delete) alphabet . T.toLower
+  where
+    alphabet :: Set Char
+    alphabet = S.fromList ['a'..'z']

--- a/exercises/pangram/package.yaml
+++ b/exercises/pangram/package.yaml
@@ -1,8 +1,9 @@
 name: pangram
-version: 1.4.1.9
+version: 1.4.1.10
 
 dependencies:
   - base
+  - text
 
 library:
   exposed-modules: Pangram

--- a/exercises/pangram/src/Pangram.hs
+++ b/exercises/pangram/src/Pangram.hs
@@ -1,4 +1,8 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Pangram (isPangram) where
 
-isPangram :: String -> Bool
+import qualified Data.Text as T
+import           Data.Text (Text)
+
+isPangram :: Text -> Bool
 isPangram text = error "You need to implement this function."

--- a/exercises/pangram/test/Tests.hs
+++ b/exercises/pangram/test/Tests.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 import Data.Foldable     (for_)
+import Data.String       (fromString)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
@@ -12,7 +14,7 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = describe "isPangram" $ for_ cases test
   where
-    test Case{..} = it description $ isPangram input `shouldBe` expected
+    test Case{..} = it description $ isPangram (fromString input) `shouldBe` expected
 
 data Case = Case { description :: String
                  , input       :: String


### PR DESCRIPTION
Pangram is the second string-heavy core exercise with Bob being the first.

As part of the `Data.Text` initiative started in #760 and tracked in #780, pangram will be the first exercise where the stub assumes the use of `Data.Text` rather than `String`.

Because the Haskell ecosystem is still adapting, and the Prelude and popular teaching material doesn't cover this extensively yet, we'll have to provide some insight into why this is desirable.

The test suite is still compatible with `String`-based solutions, but the stub does not encourage them.