### PR TITLE
pangram 1.4.1.9: Make test suite compatible with `Data.Text` (#780)

### DIFF
--- a/exercises/pangram/examples/success-text/package.yaml
+++ b/exercises/pangram/examples/success-text/package.yaml
@@ -1,16 +1,12 @@
 name: pangram
-version: 1.4.1.9
 
 dependencies:
   - base
+  - text
 
 library:
   exposed-modules: Pangram
   source-dirs: src
-  ghc-options: -Wall
-  # dependencies:
-  # - foo       # List here the packages you
-  # - bar       # want to use in your solution.
 
 tests:
   test:

--- a/exercises/pangram/examples/success-text/src/Pangram.hs
+++ b/exercises/pangram/examples/success-text/src/Pangram.hs
@@ -1,0 +1,8 @@
+module Pangram (isPangram) where
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+isPangram :: Text -> Bool
+isPangram s = all (`member` T.toLower s) ['a'..'z']
+  where member = T.any . (==)

--- a/exercises/pangram/test/Tests.hs
+++ b/exercises/pangram/test/Tests.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 import Data.Foldable     (for_)
+import Data.String       (fromString)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
@@ -12,7 +14,7 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = describe "isPangram" $ for_ cases test
   where
-    test Case{..} = it description $ isPangram input `shouldBe` expected
+    test Case{..} = it description $ isPangram (fromString input) `shouldBe` expected
 
 data Case = Case { description :: String
                  , input       :: String


### PR DESCRIPTION
This mimics the change made for bob in #760.

The only thing that is necessary for the test suite to support a

    responseFor :: Text -> Text

is to assume that it has the type `IsString s => s -> s`.

We leave the stub as `String -> String`, but make the test suite
compatible with the change. This means that mentors can suggest a
solution based on `Data.Text` if they like.

A `Data.Text`-based solution is provided as an example.

Exercise version bumped from 1.4.1.8 to 1.4.1.9