### PR TITLE
Bob: Add README hint for optional Data.Text extensions

### DIFF
--- a/exercises/bob/.meta/hints.md
+++ b/exercises/bob/.meta/hints.md
@@ -1,0 +1,33 @@
+## Hints
+
+You need to implement the `responseFor` function that returns Bob's response
+for a given input. You can use the provided signature if you are unsure
+about the types, but don't let it restrict your creativity:
+
+```haskell
+responseFor :: String -> String
+```
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell,
+- Add `- text` to your list of dependencies in package.yaml,
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+      import qualified Data.Text as T
+      import           Data.Text (Text)
+
+- You can now write e.g. `responseFor :: Text -> Text` and refer to `Data.Text` combinators as e.g. `T.isSuffixOf`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text-1.2.3.1/docs/Data-Text.html),
+
+You can then replace all occurrences of `String` with `Text` in Bob.hs:
+
+```haskell
+responseFor :: Text -> Text
+```
+
+This part is entirely optional.

--- a/exercises/bob/.meta/hints.md
+++ b/exercises/bob/.meta/hints.md
@@ -14,8 +14,8 @@ efficient handling of textual data, the `Text` type can be used.
 
 As an optional extension to this exercise, you can
 
-- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell,
-- Add `- text` to your list of dependencies in package.yaml,
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
 - Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
 
       import qualified Data.Text as T
@@ -23,11 +23,10 @@ As an optional extension to this exercise, you can
 
 - You can now write e.g. `responseFor :: Text -> Text` and refer to `Data.Text` combinators as e.g. `T.isSuffixOf`.
 - Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text-1.2.3.1/docs/Data-Text.html),
+- You can then replace all occurrences of `String` with `Text` in Bob.hs:
 
-You can then replace all occurrences of `String` with `Text` in Bob.hs:
-
-```haskell
-responseFor :: Text -> Text
-```
+      ```haskell
+      responseFor :: Text -> Text
+      ```
 
 This part is entirely optional.

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -31,8 +31,8 @@ efficient handling of textual data, the `Text` type can be used.
 
 As an optional extension to this exercise, you can
 
-- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell,
-- Add `- text` to your list of dependencies in package.yaml,
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
 - Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
 
       import qualified Data.Text as T
@@ -40,12 +40,11 @@ As an optional extension to this exercise, you can
 
 - You can now write e.g. `responseFor :: Text -> Text` and refer to `Data.Text` combinators as e.g. `T.isSuffixOf`.
 - Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text-1.2.3.1/docs/Data-Text.html),
+- You can then replace all occurrences of `String` with `Text` in Bob.hs:
 
-You can then replace all occurrences of `String` with `Text` in Bob.hs:
-
-```haskell
-responseFor :: Text -> Text
-```
+      ```haskell
+      responseFor :: Text -> Text
+      ```
 
 This part is entirely optional.
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -15,6 +15,41 @@ He answers 'Whatever.' to anything else.
 
 Bob's conversational partner is a purist when it comes to written communication and always follows normal rules regarding sentence punctuation in English.
 
+## Hints
+
+You need to implement the `responseFor` function that returns Bob's response
+for a given input. You can use the provided signature if you are unsure
+about the types, but don't let it restrict your creativity:
+
+```haskell
+responseFor :: String -> String
+```
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell,
+- Add `- text` to your list of dependencies in package.yaml,
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+      import qualified Data.Text as T
+      import           Data.Text (Text)
+
+- You can now write e.g. `responseFor :: Text -> Text` and refer to `Data.Text` combinators as e.g. `T.isSuffixOf`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text-1.2.3.1/docs/Data-Text.html),
+
+You can then replace all occurrences of `String` with `Text` in Bob.hs:
+
+```haskell
+responseFor :: Text -> Text
+```
+
+This part is entirely optional.
+
+
 
 ## Getting Started
 

--- a/exercises/bob/package.yaml
+++ b/exercises/bob/package.yaml
@@ -1,5 +1,5 @@
 name: bob
-version: 1.4.0.9
+version: 1.4.0.10
 
 dependencies:
   - base


### PR DESCRIPTION
Bob is the exercise that by far fits the use-case of `Data.Text` best.

It didn't come with any hints, so I've added a hint in two parts:

- One that is "You need to implement `responseFor :: String -> String`"
- One that elaborates on how to get started with `Data.Text` with some links on qualifying imports, adding extra dependencies and Haddock references to Data.Text.

This change addresses #780.