### PR TITLE
pangram 1.4.1.10: Add test case: determine pangram lazily

### DIFF
--- a/exercises/pangram/package.yaml
+++ b/exercises/pangram/package.yaml
@@ -1,5 +1,5 @@
 name: pangram
-version: 1.4.1.9
+version: 1.4.1.10
 
 dependencies:
   - base

--- a/exercises/pangram/test/Tests.hs
+++ b/exercises/pangram/test/Tests.hs
@@ -62,4 +62,8 @@ cases = [ Case { description = "sentence empty"
                , input       = "the quick brown fox jumps over with lazy FX"
                , expected    = False
                }
+        , Case { description = "determine pangram by terminating as soon as all letters have occurred"
+               , input       = "abcdefghijklmnopqrstuvwxyz" ++ undefined
+               , expected    = True
+               }
         ]

--- a/exercises/pangram/test/Tests.hs
+++ b/exercises/pangram/test/Tests.hs
@@ -63,7 +63,7 @@ cases = [ Case { description = "sentence empty"
                , expected    = False
                }
         {-
-        -- The following test can be enabled:
+        -- The following test can be enabled for String-based solutions:
         , Case { description = "determine pangram by terminating as soon as all letters have occurred"
                , input       = "abcdefghijklmnopqrstuvwxyz" ++ [undefined]
                , expected    = True

--- a/exercises/pangram/test/Tests.hs
+++ b/exercises/pangram/test/Tests.hs
@@ -62,8 +62,11 @@ cases = [ Case { description = "sentence empty"
                , input       = "the quick brown fox jumps over with lazy FX"
                , expected    = False
                }
+        {-
+        -- The following test can be enabled:
         , Case { description = "determine pangram by terminating as soon as all letters have occurred"
-               , input       = "abcdefghijklmnopqrstuvwxyz" ++ undefined
+               , input       = "abcdefghijklmnopqrstuvwxyz" ++ [undefined]
                , expected    = True
                }
+        -- -}
         ]


### PR DESCRIPTION
Fail if the input stream was touched beyond the first occurrence of each letter.

Many standard solutions achieve this property without much effort, and some don't.

This test case notifies the student that a more optimal solution is within reach.

It is commented out by default:

> While `success-standard` passes this test, and a `String`-based
> `fail-too-eager` example fails as expected, `success-text` cannot easily
> succeed, even if is changed into using `Data.Text.Lazy`:
> 
> One can write a `Data.Text.Lazy as LT`-specific test:
> 
>     describe "isPangram" $ do
>       it "is lazy" $
>         isPangram (LT.fromChunks ["a...z", undefined]) `shouldBe` True
> 
> But when the input comes via `fromString :: IsString s => String -> s`,
> the implementation has little control of the chunking. A failed attempt
> to circumvent this,
> 
>     newtype ChunkyLazyText = ChunkyLazyText LT.Text
> 
>     instance IsString ChunkyLazyText where
>       fromString = ChunkyLazyText . LT.fromChunks . map (T.pack . return)
> 
> still causes the `T.pack` invocation on `[undefined]`.
> 
> And as @BobDalgleish pointed out in [this StackOverflow comment][SO],
> I'd actually end up testing `fromString`. Since "laziness" doesn't mean
> the same thing for `String` as it does for `Data.Text.Lazy` because
> chunking works differently, the reliable alternative is to write tests
> for each implementation.
> 
> Or, in this case, let string-type specific tests remain commented out.
> 
> [SO]: https://stackoverflow.com/questions/53784627/testing-laziness-of-isstring-s-s-bool-function
