### PR TITLE
Hamming: Add a test case to avoid wrong recursion solution

### DIFF
--- a/exercises/hamming/package.yaml
+++ b/exercises/hamming/package.yaml
@@ -1,5 +1,5 @@
 name: hamming
-version: 2.2.0.9
+version: 2.3.0.10
 
 dependencies:
   - base

--- a/exercises/hamming/test/Tests.hs
+++ b/exercises/hamming/test/Tests.hs
@@ -61,4 +61,9 @@ cases = [ Case { description = "empty strands"
                , strand2     = "AGTG"
                , expected    = Nothing
                }
+        , Case { description = "disallow only one empty strand"
+               , strand1     = ""
+               , strand2     = "G"
+               , expected    = Nothing
+               }
         ]

--- a/exercises/hamming/test/Tests.hs
+++ b/exercises/hamming/test/Tests.hs
@@ -61,9 +61,14 @@ cases = [ Case { description = "empty strands"
                , strand2     = "AGTG"
                , expected    = Nothing
                }
-        , Case { description = "disallow only one empty strand"
+        , Case { description = "disallow left empty strand"
                , strand1     = ""
                , strand2     = "G"
+               , expected    = Nothing
+               }
+        , Case { description = "disallow right empty strand"
+               , strand1     = "G"
+               , strand2     = ""
                , expected    = Nothing
                }
         ]


### PR DESCRIPTION
This solution will pass all the current test cases but fail on the new one:

```
module Hamming (distance) where


distance :: String -> String -> Maybe Int
distance [] []         = Just 0
distance (x:xs) (y:ys)
  | length(xs) /= length(ys) = Nothing
  | x /= y = fmap (1 + ) (distance xs ys)
  | x == y = distance xs ys
```