### PR TITLE
rna-transcription: Improve README hint and example

### DIFF
--- a/exercises/rna-transcription/.meta/hints.md
+++ b/exercises/rna-transcription/.meta/hints.md
@@ -1,0 +1,1 @@
+Given invalid output, your program should return the first invalid character.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -18,6 +18,9 @@ each nucleotide with its complement:
 * `T` -> `A`
 * `A` -> `U`
 
+Given invalid output, your program should return the first invalid character.
+
+
 
 ## Getting Started
 

--- a/exercises/rna-transcription/examples/success-standard/src/DNA.hs
+++ b/exercises/rna-transcription/examples/success-standard/src/DNA.hs
@@ -1,7 +1,7 @@
 module DNA (toRNA) where
 
 toRNA :: String -> Either Char String
-toRNA = mapM fromDNA
+toRNA = traverse fromDNA
   where
     fromDNA :: Char -> Either Char Char
     fromDNA 'C' = return 'G'


### PR DESCRIPTION
Fixes #801, and finishes propagating changes from #762.
Also modified `mapM` in the example solution to `traverse`, since `traverse` is more general and preferred, and `mapM` is typically just defined as an alias for it.