### PR TITLE
travis: Change language to bash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false              # Use the container-based infrastructure.
+language: bash
 
 addons:
   apt:


### PR DESCRIPTION
my notes: A part of #751, but worth evaluating on its own.

I think this will only save about 4 seconds since that is the amount of time I see attributed to the following section of Travis build logs such as https://travis-ci.org/exercism/haskell/jobs/499951245#L440

```
$ rvm use default [4.25s]
Using /home/travis/.rvm/gems/ruby-2.4.1
** Updating RubyGems to the latest compatible version for security reasons. **
** If you need an older version, you can downgrade with 'gem update --system OLD_VERSION'. **
```

original commit message below:

---

This should speed up builds as we don't have to update rubygems constantly.

