### PR TITLE
pig-latin: Make test suite compatible with `Data.Text`

### DIFF
--- a/exercises/pig-latin/.meta/hints.md
+++ b/exercises/pig-latin/.meta/hints.md
@@ -1,0 +1,22 @@
+## Hints
+
+The unit tests provide examples of words. Try and cluster consonants
+independent of the specific combinations of consonants in the unit tests.
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+      import qualified Data.Text as T
+      import           Data.Text (Text)
+
+- You can now write e.g. `translate :: Text -> Text` and refer to `Data.Text` combinators as e.g. `T.isSuffixOf`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html),
+
+This part is entirely optional.

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -17,6 +17,30 @@ variants too.
 
 See <http://en.wikipedia.org/wiki/Pig_latin> for more details.
 
+## Hints
+
+The unit tests provide examples of words. Try and cluster consonants
+independent of the specific combinations of consonants in the unit tests.
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+      import qualified Data.Text as T
+      import           Data.Text (Text)
+
+- You can now write e.g. `translate :: Text -> Text` and refer to `Data.Text` combinators as e.g. `T.isSuffixOf`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html),
+
+This part is entirely optional.
+
+
 
 ## Getting Started
 

--- a/exercises/pig-latin/examples/success-text/package.yaml
+++ b/exercises/pig-latin/examples/success-text/package.yaml
@@ -1,5 +1,4 @@
 name: pig-latin
-version: 1.2.0.7
 
 dependencies:
   - base
@@ -8,10 +7,6 @@ dependencies:
 library:
   exposed-modules: PigLatin
   source-dirs: src
-  ghc-options: -Wall
-  # dependencies:
-  # - foo       # List here the packages you
-  # - bar       # want to use in your solution.
 
 tests:
   test:

--- a/exercises/pig-latin/examples/success-text/src/PigLatin.hs
+++ b/exercises/pig-latin/examples/success-text/src/PigLatin.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+module PigLatin (translate) where
+
+import qualified Data.Text as T
+import           Data.Text (Text)
+
+translate :: Text -> Text
+translate = T.unwords . map translateWord . T.words
+
+translateWord :: Text -> Text
+translateWord = ay . transform . consonantCluster
+
+ay :: (Text, Text) -> Text
+ay (consonants, rest) = rest <> consonants <> "ay"
+
+transform :: (Text, Text) -> (Text, Text)
+transform (consonants, rest)
+  -- Rule 1: xray -> xrayay, yttria -> yttriaay, queen -> eenquay
+  | beginsWith "xr" = (rest, consonants)
+  | beginsWith "yt" = (rest, consonants)
+  | beginsWithVowels = (consonants, rest)
+
+  -- Rule 3: square -> aresquay
+  | containsQu = (consonants <> "u", T.drop 1 rest)
+
+  -- Rule 2: equal -> equalay, rhythm -> ythmrhay, my -> ymay
+  | otherwise = (consonants, rest)
+  where
+    beginsWith = (`T.isPrefixOf` consonants)
+    beginsWithVowels = T.null consonants
+    containsQu = "q" `T.isSuffixOf` consonants && "u" `T.isPrefixOf` rest
+
+-- When a 'y' occurs beyond the first letter of a word, the consonant
+-- cluster ends before it.
+consonantCluster :: Text -> (Text, Text)
+consonantCluster = y . T.span (not . isVowel)
+  where
+    y :: (Text, Text) -> (Text, Text)
+    y (consonants, rest) = case T.findIndex (== 'y') (T.drop 1 consonants) of
+      Nothing -> (consonants, rest)
+      Just n  -> let (consonants', middle) = T.splitAt (n + 1) consonants
+                 in (consonants', middle <> rest)
+
+-- The letter 'y' is only a vowel conditionally.
+isVowel :: Char -> Bool
+isVowel = (`elem` vowels)
+  where
+    vowels :: String
+    vowels = "aeiou"

--- a/exercises/pig-latin/examples/success-text/src/PigLatin.hs
+++ b/exercises/pig-latin/examples/success-text/src/PigLatin.hs
@@ -43,7 +43,4 @@ consonantCluster = y . T.span (not . isVowel)
 
 -- The letter 'y' is only a vowel conditionally.
 isVowel :: Char -> Bool
-isVowel = (`elem` vowels)
-  where
-    vowels :: String
-    vowels = "aeiou"
+isVowel c = T.any (== c) "aeiou"

--- a/exercises/pig-latin/package.yaml
+++ b/exercises/pig-latin/package.yaml
@@ -3,7 +3,6 @@ version: 1.2.0.7
 
 dependencies:
   - base
-  - text
 
 library:
   exposed-modules: PigLatin

--- a/exercises/pig-latin/test/Tests.hs
+++ b/exercises/pig-latin/test/Tests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 


### PR DESCRIPTION
As in #760 (bob) and #788 (pangram), the only change necessary to support

    translate :: Text -> Text

is to enable OverloadedStrings in the test suite.

We leave the stub as `String -> String`, but make the test suite
compatible with the change, and we provide an optional README hint
adapted from #794 (bob). This may encourage students to pursue a
solution based on `Data.Text`, and it relieves mentors from having to
give this hint.

A `Data.Text`-based solution is provided as an example.

Exercise version bumped from 1.2.0.6 to 1.2.0.7.