### PR TITLE
binary-search: Add exercise (closes #615)

### DIFF
--- a/config.json
+++ b/config.json
@@ -560,6 +560,16 @@
       ]
     },
     {
+      "uuid": "e714ed04-e633-4814-8885-323968f39046",
+      "slug": "binary-search",
+      "core": false,
+      "unlocked_by": "collatz-conjecture",
+      "difficulty": 5,
+      "topics": [
+        "maybe"
+      ]
+    },
+    {
       "slug": "atbash-cipher",
       "uuid": "4b6d04f4-8cfc-4d8a-ac6e-77f3889f27c3",
       "core": false,

--- a/config.json
+++ b/config.json
@@ -560,8 +560,8 @@
       ]
     },
     {
-      "uuid": "e714ed04-e633-4814-8885-323968f39046",
       "slug": "binary-search",
+      "uuid": "e714ed04-e633-4814-8885-323968f39046",
       "core": false,
       "unlocked_by": "collatz-conjecture",
       "difficulty": 5,

--- a/exercises/binary-search/.meta/hints.md
+++ b/exercises/binary-search/.meta/hints.md
@@ -1,0 +1,15 @@
+## Hints
+
+Haskell has support for many types of arrays. This exercise uses immutable,
+boxed, non-strict arrays from `Data.Array`. You can read more about the use of
+these arrays on:
+
+- [A Gentle Introduction to Haskell: Arrays][1]
+- The documentation for [`Data.Array`][2]
+
+As an optional extension to this exercise, try and make the `find` function
+work for arrays with arbitrary bounds, e.g. arrays for which the first index is
+not necessarily 0.
+
+[1]: https://www.haskell.org/tutorial/arrays.html
+[2]: http://hackage.haskell.org/package/array/docs/Data-Array.html

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -1,0 +1,112 @@
+# Binary Search
+
+Implement a binary search algorithm.
+
+Searching a sorted collection is a common task. A dictionary is a sorted
+list of word definitions. Given a word, one can find its definition. A
+telephone book is a sorted list of people's names, addresses, and
+telephone numbers. Knowing someone's name allows one to quickly find
+their telephone number and address.
+
+If the list to be searched contains more than a few items (a dozen, say)
+a binary search will require far fewer comparisons than a linear search,
+but it imposes the requirement that the list be sorted.
+
+In computer science, a binary search or half-interval search algorithm
+finds the position of a specified input value (the search "key") within
+an array sorted by key value.
+
+In each step, the algorithm compares the search key value with the key
+value of the middle element of the array.
+
+If the keys match, then a matching element has been found and its index,
+or position, is returned.
+
+Otherwise, if the search key is less than the middle element's key, then
+the algorithm repeats its action on the sub-array to the left of the
+middle element or, if the search key is greater, on the sub-array to the
+right.
+
+If the remaining array to be searched is empty, then the key cannot be
+found in the array and a special "not found" indication is returned.
+
+A binary search halves the number of items to check with each iteration,
+so locating an item (or determining its absence) takes logarithmic time.
+A binary search is a dichotomic divide and conquer search algorithm.
+
+## Hints
+
+Haskell has support for many types of arrays. This exercise uses immutable,
+boxed, non-strict arrays from `Data.Array`. You can read more about the use of
+these arrays on:
+
+- [A Gentle Introduction to Haskell: Arrays][1]
+- The documentation for [`Data.Array`][2]
+
+As an optional extension to this exercise, try and make the `find` function
+work for arrays with arbitrary bounds, e.g. arrays for which the first index is
+not necessarily 0.
+
+[1]: https://www.haskell.org/tutorial/arrays.html
+[2]: http://hackage.haskell.org/package/array/docs/Data-Array.html
+
+
+
+## Getting Started
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/haskell).
+
+## Running the tests
+
+To run the test suite, execute the following command:
+
+```bash
+stack test
+```
+
+#### If you get an error message like this...
+
+```
+No .cabal file found in directory
+```
+
+You are probably running an old stack version and need
+to upgrade it.
+
+#### Otherwise, if you get an error message like this...
+
+```
+No compiler found, expected minor version match with...
+Try running "stack setup" to install the correct GHC...
+```
+
+Just do as it says and it will download and install
+the correct compiler version:
+
+```bash
+stack setup
+```
+
+## Running *GHCi*
+
+If you want to play with your solution in GHCi, just run the command:
+
+```bash
+stack ghci
+```
+
+## Feedback, Issues, Pull Requests
+
+The [exercism/haskell](https://github.com/exercism/haskell) repository on
+GitHub is the home for all of the Haskell exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue.  We'll do our best to help you!
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Binary_search_algorithm](http://en.wikipedia.org/wiki/Binary_search_algorithm)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary-search/examples/success-standard/package.yaml
+++ b/exercises/binary-search/examples/success-standard/package.yaml
@@ -1,0 +1,18 @@
+name: binary-search
+
+dependencies:
+  - base
+  - array
+
+library:
+  exposed-modules: BinarySearch
+  source-dirs: src
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - binary-search
+      - hspec
+

--- a/exercises/binary-search/examples/success-standard/package.yaml
+++ b/exercises/binary-search/examples/success-standard/package.yaml
@@ -15,4 +15,3 @@ tests:
     dependencies:
       - binary-search
       - hspec
-

--- a/exercises/binary-search/examples/success-standard/src/BinarySearch.hs
+++ b/exercises/binary-search/examples/success-standard/src/BinarySearch.hs
@@ -3,13 +3,13 @@ module BinarySearch (find) where
 import Data.Array (Array, (!), bounds)
 
 find :: Ord a => Array Int a -> a -> Maybe Int
-find array value = uncurry find_ $ bounds array
+find array value = find_ $ bounds array
   where
-    find_ :: Int -> Int -> Maybe Int
-    find_ i j
+    find_ :: (Int, Int) -> Maybe Int
+    find_ (i, j)
       | i > j                 = Nothing
-      | value < array ! pivot = find_ i (pivot-1)
-      | value > array ! pivot = find_ (pivot+1) j
+      | value < array ! pivot = find_ (i, pivot-1)
+      | value > array ! pivot = find_ (pivot+1, j)
       | otherwise             = Just pivot
       where
         pivot = (i + j) `div` 2

--- a/exercises/binary-search/examples/success-standard/src/BinarySearch.hs
+++ b/exercises/binary-search/examples/success-standard/src/BinarySearch.hs
@@ -1,0 +1,15 @@
+module BinarySearch (find) where
+
+import Data.Array (Array, (!), bounds)
+
+find :: Ord a => Array Int a -> a -> Maybe Int
+find array value = uncurry find_ $ bounds array
+  where
+    find_ :: Int -> Int -> Maybe Int
+    find_ i j
+      | i > j                 = Nothing
+      | value < array ! pivot = find_ i (pivot-1)
+      | value > array ! pivot = find_ (pivot+1) j
+      | otherwise             = Just pivot
+      where
+        pivot = (i + j) `div` 2

--- a/exercises/binary-search/package.yaml
+++ b/exercises/binary-search/package.yaml
@@ -1,0 +1,23 @@
+name: binary-search
+version: 1.3.0.0
+
+dependencies:
+  - base
+  - array
+
+library:
+  exposed-modules: BinarySearch
+  source-dirs: src
+  ghc-options: -Wall
+  # dependencies:
+  # - foo       # List here the packages you
+  # - bar       # want to use in your solution.
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - binary-search
+      - hspec
+

--- a/exercises/binary-search/package.yaml
+++ b/exercises/binary-search/package.yaml
@@ -20,4 +20,3 @@ tests:
     dependencies:
       - binary-search
       - hspec
-

--- a/exercises/binary-search/src/BinarySearch.hs
+++ b/exercises/binary-search/src/BinarySearch.hs
@@ -1,0 +1,6 @@
+module BinarySearch (find) where
+
+import Data.Array
+
+find :: Ord a => Array Int a -> a -> Maybe Int
+find array x = error "You need to implement this function."

--- a/exercises/binary-search/stack.yaml
+++ b/exercises/binary-search/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-12.4

--- a/exercises/binary-search/test/Tests.hs
+++ b/exercises/binary-search/test/Tests.hs
@@ -11,17 +11,13 @@ main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
 
 specs :: Spec
-specs = describe "find" $ -- do
-  for_ cases $ test 0
-  -- Data.Array supports arbitrary indexing. Does your implementation?
-  -- for_ cases $ test (-9)
+specs = describe "find" $ for_ bases $ for_ cases . test
   where
-    test base Case{..} = it description' $
-      find array' value `shouldBe` expected'
-      where
-        description' = description ++ " (base " ++ show base ++ ")"
-        array' = fromListWithBase base array
-        expected' = (+ base) <$> expected
+    -- Data.Array supports arbitrary indexing. Does your implementation?
+    bases = [ 0 {- , 1, -9 -} ]
+
+    test base Case{..} = it (description ++ " (base " ++ show base ++ ")") $
+      find (fromListWithBase base array) value `shouldBe` (+ base) <$> expected
 
 fromListWithBase :: Int -> [a] -> Array Int a
 fromListWithBase base xs = listArray (base, length xs - 1 + base) xs

--- a/exercises/binary-search/test/Tests.hs
+++ b/exercises/binary-search/test/Tests.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE RecordWildCards #-}
+
+import Data.Array        (Array, listArray)
+import Data.Foldable     (for_)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
+import BinarySearch      (find)
+
+main :: IO ()
+main = hspecWith defaultConfig {configFastFail = True} specs
+
+specs :: Spec
+specs = describe "find" $ -- do
+  for_ cases $ test 0
+  -- Data.Array supports arbitrary indexing. Does your implementation?
+  -- for_ cases $ test (-9)
+  where
+    test base Case{..} = it description' $
+      find array' value `shouldBe` expected'
+      where
+        description' = description ++ " (base " ++ show base ++ ")"
+        array' = fromListWithBase base array
+        expected' = (+ base) <$> expected
+
+fromListWithBase :: Int -> [a] -> Array Int a
+fromListWithBase base xs = listArray (base, length xs - 1 + base) xs
+
+data Case = Case { description :: String
+                 , array       :: [Int]
+                 , value       :: Int
+                 , expected    :: Maybe Int
+                 }
+
+cases :: [Case]
+cases =
+  [ Case { description = "finds a value in an array with one element"
+         , array       = [6]
+         , value       = 6
+         , expected    = Just 0
+         }
+  , Case { description = "finds a value in the middle of an array"
+         , array       = [1, 3, 4, 6, 8, 9, 11]
+         , value       = 6
+         , expected    = Just 3
+         }
+  , Case { description = "finds a value at the beginning of an array"
+         , array       = [1, 3, 4, 6, 8, 9, 11]
+         , value       = 1
+         , expected    = Just 0
+         }
+  , Case { description = "finds a value at the end of an array"
+         , array       = [1, 3, 4, 6, 8, 9, 11]
+         , value       = 11
+         , expected    = Just 6
+         }
+  , Case { description = "finds a value in an array of odd length"
+         , array       = [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634]
+         , value       = 144
+         , expected    = Just 9
+         }
+  , Case { description = "finds a value in an array of even length"
+         , array       = [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377]
+         , value       = 21
+         , expected    = Just 5
+         }
+  , Case { description = "identifies that a value is not included in the array"
+         , array       = [1, 3, 4, 6, 8, 9, 11]
+         , value       = 7
+         , expected    = Nothing
+         }
+  , Case { description = "a value smaller than the array's smallest value is not found"
+         , array       = [1, 3, 4, 6, 8, 9, 11]
+         , value       = 0
+         , expected    = Nothing
+         }
+  , Case { description = "a value larger than the array's largest value is not found"
+         , array       = [1, 3, 4, 6, 8, 9, 11]
+         , value       = 13
+         , expected    = Nothing
+         }
+  , Case { description = "nothing is found in an empty array"
+         , array       = []
+         , value       = 1
+         , expected    = Nothing
+         }
+  , Case { description = "nothing is found when the left and right bounds cross"
+         , array       = [1, 2]
+         , value       = 0
+         , expected    = Nothing
+         }
+  ]


### PR DESCRIPTION
Finishing @samosaara's work, this implements the binary-search exercise on the Haskell track using `Data.Array` from the `array` package. This seems to be the preferred choice cf. the discussion at #615.

In addition, a number of changes were made:

 - Unlock this after `collatz-conjecture` as the exercise deals with `Maybe`; placing it after the first exercise that deals with error handling seems natural.

 - Set exercise version number to 1.3.0.0 and update test suite. This addresses exercism/problem-specifications#1399 (version 1.3.0).

 - Add `ghc-options: -Wall` since #769.

 - Export function as `find`. This is what problem-specification calls it.

 - Generalise type signature in stub to better distinguish the type parameter for the index and the type parameter for the elements. One could generalise `Int` to `Ix i => i`, but this becomes slightly difficult when doing index arithmetic.

 - Make example solution work for arbitrary array bounds. Add test cases specific to the Haskell track that tests non-zero bounds. These cannot be expressed in problem-specifications right now, and they're only relevant for languages that can change the array base.

 - Add hint for optionally dealing with non-zero bounds.

 - Add hint with resources to `Data.Array`.