### PR TITLE
Update leap tests to 1.5.1

### DIFF
--- a/exercises/leap/package.yaml
+++ b/exercises/leap/package.yaml
@@ -1,5 +1,5 @@
 name: leap
-version: 1.4.0.8
+version: 1.5.1.9
 
 dependencies:
   - base

--- a/exercises/leap/test/Tests.hs
+++ b/exercises/leap/test/Tests.hs
@@ -25,23 +25,27 @@ data Case = Case { description :: String
                  }
 
 cases :: [Case]
-cases = [ Case { description = "year not divisible by 4: common year"
+cases = [ Case { description = "year not divisible by 4 in common year"
                , input       = 2015
                , expected    = False
                }
-        , Case { description = "year divisible by 4, not divisible by 100: leap year"
+        , Case { description = "year divisible by 2, not divisible by 4 in common year"
+               , input       = 1970
+               , expected    = False
+               }
+        , Case { description = "year divisible by 4, not divisible by 100 in leap year"
                , input       = 1996
                , expected    = True
                }
-        , Case { description = "year divisible by 100, not divisible by 400: common year"
+        , Case { description = "year divisible by 100, not divisible by 400 in common year"
                , input       = 2100
                , expected    = False
                }
-        , Case { description = "year divisible by 400: leap year"
+        , Case { description = "year divisible by 400 in leap year"
                , input       = 2000
                , expected    = True
                }
-        , Case { description = "year divisible by 200, not divisible by 400: common year"
+        , Case { description = "year divisible by 200, not divisible by 400 in common year"
                , input       = 1800
                , expected    = False
                }


### PR DESCRIPTION
Changes in `1.5.0`:
* Add new test case for `year divisible by 2, not divisible by 4 in common year`: https://github.com/exercism/problem-specifications/pull/1465

Changes in `1.5.1`:
* Remove `:` from test case description strings: https://github.com/exercism/problem-specifications/pull/1468