### PR TITLE
acronym: Make test suite compatible with `Data.Text` (#780)

### DIFF
--- a/exercises/acronym/.meta/hints.md
+++ b/exercises/acronym/.meta/hints.md
@@ -1,0 +1,19 @@
+## Hints
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+        import qualified Data.Text as T
+        import           Data.Text (Text)
+
+- You can now write e.g. `abbreviate :: Text -> Text` and refer to `Data.Text` combinators as e.g. `T.filter`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+
+This part is entirely optional.

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -7,6 +7,27 @@ Techies love their TLA (Three Letter Acronyms)!
 Help generate some jargon by writing a program that converts a long name
 like Portable Network Graphics to its acronym (PNG).
 
+## Hints
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+        import qualified Data.Text as T
+        import           Data.Text (Text)
+
+- You can now write e.g. `abbreviate :: Text -> Text` and refer to `Data.Text` combinators as e.g. `T.filter`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+
+This part is entirely optional.
+
+
 
 ## Getting Started
 

--- a/exercises/acronym/examples/success-text/package.yaml
+++ b/exercises/acronym/examples/success-text/package.yaml
@@ -1,16 +1,12 @@
 name: acronym
-version: 1.6.0.10
 
 dependencies:
   - base
+  - text
 
 library:
   exposed-modules: Acronym
   source-dirs: src
-  ghc-options: -Wall
-  # dependencies:
-  # - foo       # List here the packages you
-  # - bar       # want to use in your solution.
 
 tests:
   test:

--- a/exercises/acronym/examples/success-text/src/Acronym.hs
+++ b/exercises/acronym/examples/success-text/src/Acronym.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Acronym (abbreviate) where
+
+import           Data.Char (isUpper, isLower, isLetter, toUpper)
+import qualified Data.Text as T
+import           Data.Text (Text)
+
+abbreviate :: Text -> Text
+abbreviate s = T.filter (/= ' ') $ T.zipWith sanitize (" " <> s) (s <> " ")
+
+sanitize :: Char -> Char -> Char
+sanitize a b
+  | (a == ' ' || a == '-') && isLetter b = toUpper b
+  | isLower a && isUpper b = b
+  | otherwise = ' '

--- a/exercises/acronym/test/Tests.hs
+++ b/exercises/acronym/test/Tests.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 import Data.Foldable     (for_)
+import Data.String       (fromString)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
@@ -12,7 +14,8 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = describe "abbreviate" $ for_ cases test
   where
-    test Case {..} = it description $ abbreviate input `shouldBe` expected
+    test Case {..} = it description $
+      abbreviate (fromString input) `shouldBe` fromString expected
 
 data Case = Case { description :: String
                  , input       :: String


### PR DESCRIPTION
As part of #780, use `Data.Text` when appropriate.

And as in #760 (bob), #788 (pangram) and #805 (pig-latin), the only
change necessary to support

    abbreviate :: Text -> Text

is to enable OverloadedStrings in the test suite.

We leave the stub as `String -> String`, but make the test suite
compatible with the change, and we provide an optional README hint
adapted from #805 (pig-latin). This may encourage students to pursue a
solution based on `Data.Text`, and it relives mentors from having to
give this hint.

A `Data.Text`-based solution is provided as an example.

Exercise version bumped from 1.6.0.9 to 1.6.0.10.