### PR TITLE
isogram: Make test suite compatible with `Data.Text` (#780)

### DIFF
--- a/exercises/isogram/.meta/hints.md
+++ b/exercises/isogram/.meta/hints.md
@@ -1,0 +1,19 @@
+## Hints
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+        import qualified Data.Text as T
+        import           Data.Text (Text)
+
+- You can now write e.g. `isIsogram :: Text -> Bool` and refer to `Data.Text` combinators as e.g. `T.toLower`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+
+This part is entirely optional.

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -13,6 +13,27 @@ Examples of isograms:
 
 The word *isograms*, however, is not an isogram, because the s repeats.
 
+## Hints
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+        import qualified Data.Text as T
+        import           Data.Text (Text)
+
+- You can now write e.g. `isIsogram :: Text -> Bool` and refer to `Data.Text` combinators as e.g. `T.toLower`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+
+This part is entirely optional.
+
+
 
 ## Getting Started
 

--- a/exercises/isogram/examples/success-text/package.yaml
+++ b/exercises/isogram/examples/success-text/package.yaml
@@ -1,16 +1,14 @@
 name: isogram
-version: 1.7.0.8
 
 dependencies:
   - base
+  - containers
+  - text
+  - mono-traversable
 
 library:
   exposed-modules: Isogram
   source-dirs: src
-  ghc-options: -Wall
-  # dependencies:
-  # - foo       # List here the packages you
-  # - bar       # want to use in your solution.
 
 tests:
   test:

--- a/exercises/isogram/examples/success-text/src/Isogram.hs
+++ b/exercises/isogram/examples/success-text/src/Isogram.hs
@@ -1,23 +1,16 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Isogram (isIsogram) where
 
-import qualified Data.Char as C
-import qualified Data.Maybe as M
-import qualified Data.Set as S
-import           Data.Set (Set)
-import qualified Data.Text as T
-import           Data.Text (Text)
-
+import Data.Char (isLetter)
+import Data.Maybe (isJust)
 import Data.MonoTraversable (ofoldM)
+import Data.Set (Set, empty, member, insert)
+import Data.Text (Text)
+import qualified Data.Text as T
 
 isIsogram :: Text -> Bool
-isIsogram = M.isJust . isogram
-
-isogram :: Text -> Maybe (Set Char)
-isogram = ofoldM gather S.empty . T.toLower
+isIsogram = isJust . ofoldM gather empty . T.toLower . T.filter isLetter
   where
     gather :: Set Char -> Char -> Maybe (Set Char)
     gather seen c
-      | c `S.member` seen = Nothing
-      | not (C.isLetter c) = return seen
-      | otherwise = return (S.insert c seen)
+      | c `member` seen = Nothing
+      | otherwise = return (insert c seen)

--- a/exercises/isogram/examples/success-text/src/Isogram.hs
+++ b/exercises/isogram/examples/success-text/src/Isogram.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Isogram (isIsogram) where
+
+import qualified Data.Char as C
+import qualified Data.Maybe as M
+import qualified Data.Set as S
+import           Data.Set (Set)
+import qualified Data.Text as T
+import           Data.Text (Text)
+
+import Data.MonoTraversable (ofoldM)
+
+isIsogram :: Text -> Bool
+isIsogram = M.isJust . isogram
+
+isogram :: Text -> Maybe (Set Char)
+isogram = ofoldM gather S.empty . T.toLower
+  where
+    gather :: Set Char -> Char -> Maybe (Set Char)
+    gather seen c
+      | c `S.member` seen = Nothing
+      | not (C.isLetter c) = return seen
+      | otherwise = return (S.insert c seen)

--- a/exercises/isogram/test/Tests.hs
+++ b/exercises/isogram/test/Tests.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 import Data.Foldable     (for_)
+import Data.String       (fromString)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
@@ -15,8 +17,7 @@ specs = describe "isIsogram" $ for_ cases test
 
     test Case{..} = it description assertion
       where
-        assertion = isIsogram input `shouldBe` expected
-
+        assertion = isIsogram (fromString input) `shouldBe` expected
 
 data Case = Case { description :: String
                  , input       :: String


### PR DESCRIPTION
As part of #780, use `Data.Text` when appropriate.

The only change necessary to support

    isIsogram :: Text -> Bool

is to enable OverloadedStrings in the test suite.

We leave the stub as `String -> String`, but make the test suite
compatible with the change, and we provide an optional README hint
adapted from #805 (pig-latin). This may encourage students to pursue a
solution based on `Data.Text`, and it relieves mentors from having to
give this hint.

A `Data.Text`-based solution is provided as an example.

This example uses mono-traversable for monomorphic folding.

Exercise version bumped from 1.7.0.7 to 1.7.0.8.