### PR TITLE
dnd-character: Remove name property

### DIFF
--- a/exercises/dnd-character/examples/success-standard/src/DND.hs
+++ b/exercises/dnd-character/examples/success-standard/src/DND.hs
@@ -5,8 +5,7 @@ import Control.Monad (replicateM)
 import Test.QuickCheck.Gen (Gen, choose)
 
 data Character = Character
-  { name         :: String
-  , strength     :: Int
+  { strength     :: Int
   , dexterity    :: Int
   , constitution :: Int
   , intelligence :: Int
@@ -26,7 +25,6 @@ ability = do
 
 character :: Gen Character
 character = do
-  let name = "Bob"
   strength <- ability
   dexterity <- ability
   constitution <- ability

--- a/exercises/dnd-character/package.yaml
+++ b/exercises/dnd-character/package.yaml
@@ -1,5 +1,5 @@
 name: dnd-character
-version: 1.1.0.0
+version: 1.1.0.1
 
 dependencies:
   - base

--- a/exercises/dnd-character/src/DND.hs
+++ b/exercises/dnd-character/src/DND.hs
@@ -7,8 +7,7 @@ module DND ( Character(..)
 import Test.QuickCheck (Gen)
 
 data Character = Character
-  { name         :: String
-  , strength     :: Int
+  { strength     :: Int
   , dexterity    :: Int
   , constitution :: Int
   , intelligence :: Int


### PR DESCRIPTION
The name of the D&D character was provided as inspiration for populating the `Character` type with additional fields that may be relevant in some practical context.

But it doesn't serve a purpose, and the remaining abilities should also serve as inspiration. Having seen a few solutions default the name to `""`, the name should be removed in the context of this exercise.