### PR TITLE
etl: Make test suite compatible with `Data.Text` (#780)

### DIFF
--- a/exercises/etl/.meta/hints.md
+++ b/exercises/etl/.meta/hints.md
@@ -1,0 +1,19 @@
+## Hints
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+        import qualified Data.Text as T
+        import           Data.Text (Text)
+
+- You can now write e.g. `transform :: Map Int Text -> Map Char Int` and refer to `Data.Text` combinators as e.g. `T.toLower`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+
+This part is entirely optional.

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -46,6 +46,27 @@ variety of languages, each with its own unique scoring table. For
 example, an "E" is scored at 2 in the Māori-language version of the
 game while being scored at 4 in the Hawaiian-language version.
 
+## Hints
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+        import qualified Data.Text as T
+        import           Data.Text (Text)
+
+- You can now write e.g. `transform :: Map Int Text -> Map Char Int` and refer to `Data.Text` combinators as e.g. `T.toLower`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+
+This part is entirely optional.
+
+
 
 ## Getting Started
 

--- a/exercises/etl/examples/success-text/package.yaml
+++ b/exercises/etl/examples/success-text/package.yaml
@@ -1,17 +1,13 @@
 name: etl
-version: 1.0.0.5
 
 dependencies:
   - base
   - containers
+  - text
 
 library:
   exposed-modules: ETL
   source-dirs: src
-  ghc-options: -Wall
-  # dependencies:
-  # - foo       # List here the packages you
-  # - bar       # want to use in your solution.
 
 tests:
   test:

--- a/exercises/etl/examples/success-text/src/ETL.hs
+++ b/exercises/etl/examples/success-text/src/ETL.hs
@@ -1,0 +1,14 @@
+module ETL (transform) where
+
+import qualified Data.Map as M
+import           Data.Map (Map)
+import qualified Data.Text as T
+import           Data.Text (Text)
+
+type PointValue = Int
+type UpperTiles = Text
+type LowerTile = Char
+
+transform :: Map PointValue UpperTiles -> Map LowerTile PointValue
+transform = M.fromList . concatMap go . M.toList
+  where go (v, tiles) = zip (T.unpack (T.toLower tiles)) (repeat v)

--- a/exercises/etl/test/Tests.hs
+++ b/exercises/etl/test/Tests.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 import Data.Map          (fromList)
 import Test.Hspec        (Spec, describe, it, shouldBe)


### PR DESCRIPTION
The only change necessary to support

    transform :: Map Int Text -> Map Char Int

is to enable OverloadedStrings in the test suite.

We leave the stub as `Map a String -> Map Char a`, but make the test suite compatible with the change, and we provide an optional README hint adapted from #812 (isogram). This may encourage students to pursue a solution based on `Data.Text`, and it relieves mentors from having to give this hint.

A `Data.Text`-based solution is provided as an example.

Exercise version bumped from 1.0.0.4 to 1.0.0.5