### PR TITLE
triangle: Add `Ord` constraint to handout stub

### DIFF
--- a/exercises/triangle/package.yaml
+++ b/exercises/triangle/package.yaml
@@ -1,5 +1,5 @@
 name: triangle
-version: 0.1.0.3
+version: 0.1.0.4
 
 dependencies:
   - base

--- a/exercises/triangle/src/Triangle.hs
+++ b/exercises/triangle/src/Triangle.hs
@@ -6,5 +6,5 @@ data TriangleType = Equilateral
                   | Illegal
                   deriving (Eq, Show)
 
-triangleType :: Num a => a -> a -> a -> TriangleType
+triangleType :: (Num a, Ord a) => a -> a -> a -> TriangleType
 triangleType a b c = error "You need to implement this function."


### PR DESCRIPTION
As @phlummox commented in 9f2d160753fc0cb0dbc2536cd937a4eb9978114f,

> [...] adding a type signature to triangleType seems to suggest [...]
> that the problem can be solved by implementing a function of that type.

As we cannot think of a solution with only `Num` and not either `Ord` or
`Eq`, we add `Ord` to the handout stub as this provides most flexibility.