### PR TITLE
Add "An opinionated beginner's guide to Haskell" as learning resource

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -5,6 +5,7 @@ learning Haskell can feel different than simply picking up another language.
 Fortunately there are numerous resources which presume some programming knowledge to begin with, such
 as
 
+  - An opinionated beginner's guide to Haskell ([2019](https://github.com/theindigamer/not-a-blog/blob/master/opinionated-haskell-guide-2019.md), [2018](https://lexi-lambda.github.io/blog/2018/02/10/an-opinionated-guide-to-haskell-in-2018/))
   - the popular and free online book [Learn You a Haskell For Great Good!](http://learnyouahaskell.com/)
   - University of Glasgow's [Functional Programming in Haskell](https://www.futurelearn.com/courses/functional-programming-haskell) course
   - FP Complete's [School of Haskell](https://www.schoolofhaskell.com/)


### PR DESCRIPTION
This resource was referenced in Haskell Weekly 164, 2019-06-19. It
amends the 2018 edition, and so both of these are added as resources.

They appear to address newcomers in particular.