### PR TITLE
travis: reject invalid UUIDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,16 @@ script:
         exit 1
     fi
  - |
+   # Check for invalid UUIDs.
+   # can be removed once `configlet lint` gains this ability.
+   # Check issue https://github.com/exercism/configlet/issues/99
+   bad_uuid=$(jq --raw-output '.exercises | map(.uuid) | .[]' config.json | grep -vE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+   if [ -n "$bad_uuid" ]; then
+     echo "invalid UUIDs found! please correct these to be valid UUIDs:"
+     echo "$bad_uuid"
+     exit 1
+   fi
+ - |
     set -e
 
     configlet lint .          # Check basic track configuration.

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   "exercises": [
     {
       "slug": "hello-world",
-      "uuid": "c97d9dda-c7ee-4595-b447-693559d03ba5",
+      "uuid": "c97d9dda-c7ee-4595-b447-693559d03ba",
       "core": true,
       "auto_approve": true,
       "unlocked_by": null,
@@ -18,7 +18,7 @@
     },
     {
       "slug": "leap",
-      "uuid": "0ad7d756-1cbd-44f4-a64f-0dc7e9eb40f4",
+      "uuid": "0ad7d756-1cbd-44f4-a64f-0dc7e9eb40f40",
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
@@ -28,7 +28,7 @@
     },
     {
       "slug": "space-age",
-      "uuid": "6cbb7841-9d96-4528-88e3-6e98a450fd7c",
+      "uuid": "6cbb7841-9d96-4528-88e3-6e98a450fd7g",
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   "exercises": [
     {
       "slug": "hello-world",
-      "uuid": "c97d9dda-c7ee-4595-b447-693559d03ba",
+      "uuid": "c97d9dda-c7ee-4595-b447-693559d03ba5",
       "core": true,
       "auto_approve": true,
       "unlocked_by": null,
@@ -18,7 +18,7 @@
     },
     {
       "slug": "leap",
-      "uuid": "0ad7d756-1cbd-44f4-a64f-0dc7e9eb40f40",
+      "uuid": "0ad7d756-1cbd-44f4-a64f-0dc7e9eb40f4",
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
@@ -28,7 +28,7 @@
     },
     {
       "slug": "space-age",
-      "uuid": "6cbb7841-9d96-4528-88e3-6e98a450fd7g",
+      "uuid": "6cbb7841-9d96-4528-88e3-6e98a450fd7c",
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,


### PR DESCRIPTION
Want to prevent any invalid UUIDs from being entered.

Want to put this in configlet lint, but can't:
exercism/configlet#99
exercism/configlet#168
So it will go in individual tracks' .travis.yml for now.

It appears that the site will accept pretty much arbitrary strings as
UUIDs for now, but we want to make less work for ourselves when valid
UUIDs are required.