### PR TITLE
matrix 1.1.0.6: Use 1-based indices

### DIFF
--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -14,11 +14,11 @@ So given a string with embedded newlines like:
 representing this matrix:
 
 ```text
-    0  1  2
+    1  2  3
   |---------
-0 | 9  8  7
-1 | 5  3  2
-2 | 6  6  7
+1 | 9  8  7
+2 | 5  3  2
+3 | 6  6  7
 ```
 
 your code should be able to spit out:

--- a/exercises/matrix/examples/success-standard/src/Matrix.hs
+++ b/exercises/matrix/examples/success-standard/src/Matrix.hs
@@ -30,12 +30,12 @@ shape = matrixRows &&& matrixCols
 row :: Int -> Matrix a -> V.Vector a
 row n m = V.slice i numCols $ matrixCells m
   where numCols = matrixCols m
-        i = n * numCols
+        i = pred n * numCols
 
 column :: Int -> Matrix a -> V.Vector a
 column n m = V.backpermute (matrixCells m) indexes
   where numCols = matrixCols m
-        indexes = V.generate (matrixRows m) ((n +) . (numCols *))
+        indexes = V.generate (matrixRows m) ((pred n +) . (numCols *))
 
 transpose :: Matrix a -> Matrix a
 transpose m = mkMatrix (numCols, numRows) permuted

--- a/exercises/matrix/package.yaml
+++ b/exercises/matrix/package.yaml
@@ -1,5 +1,5 @@
 name: matrix
-version: 1.0.0.6
+version: 1.1.0.7
 
 dependencies:
   - base

--- a/exercises/matrix/test/Tests.hs
+++ b/exercises/matrix/test/Tests.hs
@@ -28,28 +28,28 @@ specs = do
     let vector = Vector.fromList
 
     it "extract row from one number matrix" $
-      row 0 (intMatrix "1") `shouldBe` vector [1]
+      row 1 (intMatrix "1") `shouldBe` vector [1]
 
     it "can extract row" $
-      row 1 (intMatrix "1 2\n3 4") `shouldBe` vector [3, 4]
+      row 2 (intMatrix "1 2\n3 4") `shouldBe` vector [3, 4]
 
     it "extract row where numbers have different widths" $
-      row 1 (intMatrix "1 2\n10 20") `shouldBe` vector [10, 20]
+      row 2 (intMatrix "1 2\n10 20") `shouldBe` vector [10, 20]
 
     it "can extract row from non-square matrix" $
-      row 2 (intMatrix "1 2 3\n4 5 6\n7 8 9\n8 7 6") `shouldBe` vector [7, 8, 9]
+      row 3 (intMatrix "1 2 3\n4 5 6\n7 8 9\n8 7 6") `shouldBe` vector [7, 8, 9]
 
     it "extract column from one number matrix" $
-      column 0 (intMatrix "1") `shouldBe` vector [1]
+      column 1 (intMatrix "1") `shouldBe` vector [1]
 
     it "can extract column" $
-      column 2 (intMatrix "1 2 3\n4 5 6\n7 8 9") `shouldBe` vector [3, 6, 9]
+      column 3 (intMatrix "1 2 3\n4 5 6\n7 8 9") `shouldBe` vector [3, 6, 9]
 
     it "can extract column from non-square matrix" $
-      column 2 (intMatrix "1 2 3\n4 5 6\n7 8 9\n8 7 6") `shouldBe` vector [3, 6, 9, 6]
+      column 3 (intMatrix "1 2 3\n4 5 6\n7 8 9\n8 7 6") `shouldBe` vector [3, 6, 9, 6]
 
     it "extract column where numbers have different widths" $
-      column 1 (intMatrix "89 1903 3\n18 3 1\n9 4 800") `shouldBe` vector [1903, 3, 4]
+      column 2 (intMatrix "89 1903 3\n18 3 1\n9 4 800") `shouldBe` vector [1903, 3, 4]
 
     -- Track-specific tests:
 


### PR DESCRIPTION
The READMEs now have 1-based indices but the tests still have 0-based.

Before these can be merged, must decide between various solutions:

1. Change the tests to be one-indexed.
2. Maintain our own README with zero-based indices. You do this by placing the README we want in `.meta/description.md`. Not recommended.
    * We cannot just use hints.md since that only allows additive changes. This is a modification of existing text, which hints.md does not support.
3. Keep both the README and tests as is, but insert a statement somewhere (hints.md, or the tests) telling students to be aware of the discrepancy.
4. Suggest to problem-specifications that no, really, they should go back to using zero-based indices.
5. Your suggestion here.

