### PR TITLE
Connect: remove obsolete sentence from description

### DIFF
--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -15,8 +15,7 @@ Your goal is to build a program that given a simple representation of a board
 computes the winner (or lack thereof). Note that all games need not be "fair".
 (For example, players may have mismatched piece counts.)
 
-The boards look like this (with spaces added for readability, which won't be in
-the representation passed to your code):
+The boards look like this:
 
 ```text
 . O . X .

--- a/exercises/connect/examples/success-standard/src/Connect.hs
+++ b/exercises/connect/examples/success-standard/src/Connect.hs
@@ -21,12 +21,12 @@ parseLines [] = error "Empty lines"
 parseLines ([]:_) = error "Empty first line"
 parseLines lines@(firstLine:_) =
   let height = length lines
-      width = length firstLine
+      width = length (filter (/= ' ') firstLine)
   in A.array ((0,0),(width - 1,height - 1)) fieldAssocs
   where fieldAssocs :: [((Int,Int),Maybe Mark)]
         fieldAssocs =
           do (l,y) <- zip lines [0 ..]
-             (c,x) <- zip l [0 ..]
+             (c,x) <- zip (filter (/= ' ') l) [0 ..]
              let f = case c of
                      'O' -> Just Nought
                      'X' -> Just Cross

--- a/exercises/connect/package.yaml
+++ b/exercises/connect/package.yaml
@@ -1,5 +1,5 @@
 name: connect
-version: 1.1.0.5
+version: 1.1.0.6
 
 dependencies:
   - base

--- a/exercises/connect/test/Tests.hs
+++ b/exercises/connect/test/Tests.hs
@@ -15,8 +15,7 @@ specs = describe "winner" $ for_ cases test
 
     test Case{..} = it description assertion
       where
-        assertion  = winner testBoard `shouldBe` expected
-        testBoard  = filter (/=' ') <$> board
+        assertion  = winner board `shouldBe` expected
 
 data Case = Case { description :: String
                  , board       :: [String]


### PR DESCRIPTION
The "obsolete" sentence says that the tests won't have spaces. Now it is unspecified, but it would be unclear if the README had spaces and the tests don't have spaces.

We remove spaces in tests:
https://github.com/exercism/haskell/blob/master/exercises/connect/test/Tests.hs#L19

Before deciding, must decide:

1. Change the tests to no longer remove spaces.
2. Keep both the README and tests as is, but insert a statement somewhere (hints.md, or the tests) telling students to be aware of the discrepancy.
3. Suggest to problem-specifications that no, really, they should reinstate the stipulation about spaces not being present.
4. Your suggestion here.

original commit msg:

---


The canonical test input is now similar to what is shown in the
description, but the description says it isn't.

Fixes https://github.com/exercism/problem-specifications/issues/1435.

https://github.com/exercism/problem-specifications/pull/1513

