### PR TITLE
saddle-points 1.5.0.8: use 1-based coordinates

### DIFF
--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -8,11 +8,11 @@ So say you have a matrix like so:
     0  1  2
   |---------
 0 | 9  8  7
-1 | 5  3  2     <--- saddle point at (1,0)
+1 | 5  3  2     <--- saddle point at column 0, row 1, with value 5
 2 | 6  6  7
 ```
 
-It has a saddle point at (1, 0).
+It has a saddle point at column 0, row 1.
 
 It's called a "saddle point" because it is greater than or equal to
 every element in its row and less than or equal to every element in

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -5,14 +5,14 @@ Detect saddle points in a matrix.
 So say you have a matrix like so:
 
 ```text
-    0  1  2
+    1  2  3
   |---------
-0 | 9  8  7
-1 | 5  3  2     <--- saddle point at column 0, row 1, with value 5
-2 | 6  6  7
+1 | 9  8  7
+2 | 5  3  2     <--- saddle point at column 1, row 2, with value 5
+3 | 6  6  7
 ```
 
-It has a saddle point at column 0, row 1.
+It has a saddle point at column 1, row 2.
 
 It's called a "saddle point" because it is greater than or equal to
 every element in its row and less than or equal to every element in

--- a/exercises/saddle-points/package.yaml
+++ b/exercises/saddle-points/package.yaml
@@ -1,5 +1,5 @@
 name: saddle-points
-version: 1.3.0.7
+version: 1.5.0.8
 
 dependencies:
   - array

--- a/exercises/saddle-points/test/Tests.hs
+++ b/exercises/saddle-points/test/Tests.hs
@@ -19,12 +19,12 @@ specs = describe "saddlePoints" $ for_ cases test
         assertion = saddlePoints matrix `shouldBe` expected
         rows      = length xss
         columns   = length $ head xss
-        matrix    = listArray ((0, 0), (rows - 1, columns - 1)) (concat xss)
+        matrix    = listArray ((1, 1), (rows, columns)) (concat xss)
 
     cases = [ ( "Example from README",
                 [ [9, 8, 7]
                 , [5, 3, 2]
-                , [6, 6, 7] ], [(1, 0)] )
+                , [6, 6, 7] ], [(2, 1)] )
 
             , ( "empty matrix has none", [], [] )
 
@@ -36,35 +36,35 @@ specs = describe "saddlePoints" $ for_ cases test
             , ( "multiple saddle points in a column",
                 [ [4, 5, 4]
                 , [3, 5, 5]
-                , [1, 5, 4] ], [ (0, 1)
-                               , (1, 1)
-                               , (2, 1) ] )
+                , [1, 5, 4] ], [ (1, 2)
+                               , (2, 2)
+                               , (3, 2) ] )
 
             , ( "multiple saddle points in a row",
                 [ [6, 7, 8]
                 , [5, 5, 5]
-                , [7, 5, 6] ], [ (1, 0)
-                               , (1, 1)
-                               , (1, 2) ] )
+                , [7, 5, 6] ], [ (2, 1)
+                               , (2, 2)
+                               , (2, 3) ] )
 
             , ( "bottom-right corner",
                 [ [8, 7, 9]
                 , [6, 7, 6]
-                , [3, 2, 5] ], [(2, 2)] )
+                , [3, 2, 5] ], [(3, 3)] )
 
             , ( "non-square matrix",
                 [ [3, 1, 3]
-                , [3, 2, 4] ], [ (0, 0)
-                               , (0, 2) ] )
+                , [3, 2, 4] ], [ (1, 1)
+                               , (1, 3) ] )
 
             , ( "Can identify that saddle points in a single column matrix are those with the minimum value",
                 [ [2]
                 , [1]
                 , [4]
-                , [1] ], [ (1, 0)
-                         , (3, 0) ] )
+                , [1] ], [ (2, 1)
+                         , (4, 1) ] )
 
             , ( "Can identify that saddle points in a single row matrix are those with the maximum value",
-                [ [2, 5, 3, 5] ], [ (0, 1)
-                                  , (0, 3) ] )
+                [ [2, 5, 3, 5] ], [ (1, 2)
+                                  , (1, 4) ] )
             ]


### PR DESCRIPTION
1.4.0: 1-based coordinates
exercism/problem-specifications#1429
1.5.0: fix an erroneous coordinate
exercism/problem-specifications#1434

Matches `Data.Matrix.getElem` from `matrix`:
https://hackage.haskell.org/package/matrix-0.3.6.1/docs/Data-Matrix.html#v:getElem

---

I think these commits make sense *not* to squash (and if I were merging them, I would not squash), but I will live if they are squashed.