### PR TITLE
Diamond: Implement property-based tests

### DIFF
--- a/exercises/diamond/examples/success-standard/package.yaml
+++ b/exercises/diamond/examples/success-standard/package.yaml
@@ -14,3 +14,4 @@ tests:
     dependencies:
       - diamond
       - hspec
+      - QuickCheck

--- a/exercises/diamond/examples/success-standard/src/Diamond.hs
+++ b/exercises/diamond/examples/success-standard/src/Diamond.hs
@@ -2,15 +2,11 @@ module Diamond (diamond) where
 
 import Data.Char (ord, chr)
 
-pad :: Int -> String
-pad x = replicate x ' '
-
-oneRow :: Char -> (Int, Int) -> String
-oneRow c (0, y) = pad y ++ [c] ++ pad y
-oneRow c (x, y) = pad y ++ [c] ++ pad x ++ [c] ++ pad y
-
 diamond :: Char -> Maybe [String]
-diamond = Just . (\x -> x ++ tail (reverse x)) . mkTop . subtract 64 . ord
-  where rows x = zip (0 : take (x-1) [1, 3..]) [x-1, x-2..0]
-        mkTop  = zipWith oneRow abc . rows
-        abc    = map chr [65..90]
+diamond c | c `notElem` ['A'..'Z'] = Nothing
+diamond c = Just . mirror . map row $ [0..n] where
+  n = ord c - ord 'A'
+  mirror top = top ++ reverse (init top)
+  row i = mirror $ spaces (n - i) ++ [letter i] ++ spaces i
+  letter i = chr (ord 'A' + i)
+  spaces i = replicate i ' '

--- a/exercises/diamond/package.yaml
+++ b/exercises/diamond/package.yaml
@@ -1,5 +1,5 @@
 name: diamond
-version: 1.1.0.4
+version: 1.1.0.5
 
 dependencies:
   - base
@@ -19,3 +19,4 @@ tests:
     dependencies:
       - diamond
       - hspec
+      - QuickCheck

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -3,15 +3,21 @@
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.QuickCheck   (Gen, oneof, forAll)
+import Data.List         ((\\))
+import Data.Maybe        (isNothing)
 import Diamond (diamond)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
 
 specs :: Spec
-specs = describe "diamond" $ for_ cases test
+specs = describe "diamond" $ do
+  it "non-Alpha characters should produce `Nothing`" $
+    forAll genNonAlphaChars $
+      isNothing . diamond
+  for_ cases test
   where
-
     test Case{..} = it description assertion
       where
         assertion = diamond input `shouldBe` Just expected
@@ -107,3 +113,7 @@ cases = [ Case { description = "Degenerate case with a single 'A' row"
                         "                         A                         "]
                }
         ]
+
+genNonAlphaChars :: Gen Char
+genNonAlphaChars = oneof $ pure <$> nonAlphaChars
+  where nonAlphaChars = ['\0' .. '\127'] \\ (['A' .. 'Z'] ++ ['a' .. 'z'])

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -115,5 +115,5 @@ cases = [ Case { description = "Degenerate case with a single 'A' row"
         ]
 
 genNonAlphaChars :: Gen Char
-genNonAlphaChars = oneof $ pure <$> nonAlphaChars
+genNonAlphaChar = elements nonAlphaChars
   where nonAlphaChars = ['\0' .. '\127'] \\ (['A' .. 'Z'] ++ ['a' .. 'z'])

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE LambdaCase #-}
 
 import Data.Foldable       (for_)
 import Test.Hspec          (Spec, describe, it, shouldBe, pending)
@@ -13,8 +14,8 @@ import Test.QuickCheck     ( Gen
                            , Property
                            )
 import Data.Maybe          (isNothing, isJust, fromMaybe)
-import Data.Char           (ord, isLetter, isUpper, isPrint)
-import Control.Applicative (liftA2)
+import Data.Char           (ord, isLetter, isPrint)
+import Data.List           (isSuffixOf)
 import Diamond (diamond)
 
 main :: IO ()
@@ -42,7 +43,10 @@ specs = describe "diamond" $ do
     forAllCharDiamond checkCorrectDimensions
 
   it "rows should start and end with the same character" $
-    forAllDiamond $ all checkFirstAndLastCharEq
+    forAllDiamond $
+      let headEqualsLast ys = not (null ys) && take 1 ys `isSuffixOf` ys
+      in \case [] -> False
+               xs -> all headEqualsLast $ filter isLetter <$> xs
 
   for_ cases test
   where
@@ -189,9 +193,3 @@ shrinkNonAlphaChar c = if isPrint c
                         else printableChars
   where
     printableChars = filter isPrint ['\0' .. '\127']
-
-checkFirstAndLastCharEq :: String -> Bool
--- checkFirstAndLastCharEq xs = head letters == tail letters
-checkFirstAndLastCharEq xs = liftA2 (==) head last letters
-  where
-    letters = filter isLetter xs

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -188,8 +188,9 @@ checkCorrectDimensions c xs = length xs == dim && all ((== dim) . length) xs
     dim = 2 * position c + 1
 
 shrinkNonAlphaChar :: Char -> String
-shrinkNonAlphaChar c = if isPrint c
-                        then takeWhile (/= c) printableChars
-                        else printableChars
+shrinkNonAlphaChar c =
+  if isPrint c
+   then takeWhile (/= c) printableChars
+   else printableChars
   where
     printableChars = filter isPrint ['\0' .. '\127']

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -17,7 +17,7 @@ import Test.QuickCheck     ( Gen
                            , discard
                            )
 import Data.Maybe          (isNothing, isJust)
-import Data.Char           (ord, isLetter, isPrint, isSpace)
+import Data.Char           (isLetter, isPrint, isSpace)
 import Data.List           (isSuffixOf)
 import Diamond (diamond)
 

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -3,10 +3,10 @@
 import Data.Char         (isLetter, isPrint, isSpace)
 import Data.Foldable     (for_)
 import Data.List         (isSuffixOf)
-import Data.Maybe        (isNothing, isJust)
+import Data.Maybe        (isJust, isNothing)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
-import Test.QuickCheck   (arbitraryASCIIChar, counterexample, conjoin,
+import Test.QuickCheck   (arbitraryASCIIChar, conjoin, counterexample,
                           discard, elements, forAll, forAllShrink, Gen,
                           Property, suchThat, Testable, (===))
 

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -12,6 +12,7 @@ import Test.QuickCheck     ( Gen
                            , suchThat
                            , Testable
                            , Property
+                           , (===)
                            )
 import Data.Maybe          (isNothing, isJust, fromMaybe)
 import Data.Char           (ord, isLetter, isPrint, isSpace)
@@ -34,10 +35,9 @@ specs = describe "diamond" $ do
     forAllDiamond $ odd . length
 
   it "should have equal top and bottom" $
-    forAllDiamond topEqualToBottom
-
-  it "should have the correct middle row" $
-    forAllCharDiamond checkMiddle
+    forAllDiamond $ \diamond ->
+      let halfRoundDown = length diamond `div` 2
+       in take halfRoundDown diamond === take halfRoundDown (reverse diamond)
 
   it "should have the same width and height" $
     forAllCharDiamond checkCorrectDimensions
@@ -163,24 +163,8 @@ forAllDiamond = forAllCharDiamond . const
 forAllCharDiamond :: Testable prop => (Char -> [String] -> prop) -> Property
 forAllCharDiamond p = forAll genDiamond $ uncurry p . fmap (fromMaybe [""])
 
-topLength :: [String] -> Int
-topLength = (`div` 2) . length
-
 position :: Char -> Int
 position c = ord c - ord 'A'
-
-topEqualToBottom :: [String] -> Bool
-topEqualToBottom xs = take len xs == take len (reverse xs)
-  where
-    len = topLength xs
-
-checkMiddle :: Char -> [String] -> Bool
-checkMiddle c xs = getMiddle xs == middle
-  where
-    getMiddle ys = ys !! topLength ys
-    leftSide = c : replicate (position c) ' '
-    rightSide = tail . reverse $ leftSide
-    middle = leftSide ++ rightSide
 
 checkCorrectDimensions :: Char -> [String] -> Bool
 checkCorrectDimensions c xs = length xs == dim && all ((== dim) . length) xs

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -1,24 +1,16 @@
 {-# LANGUAGE RecordWildCards #-}
 
+import Data.Char         (isLetter, isPrint, isSpace)
 import Data.Foldable     (for_)
+import Data.List         (isSuffixOf)
+import Data.Maybe        (isNothing, isJust)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
-import Test.QuickCheck   ( Gen
-                         , elements
-                         , forAll
-                         , forAllShrink
-                         , arbitraryASCIIChar
-                         , suchThat
-                         , Testable
-                         , Property
-                         , (===)
-                         , counterexample
-                         , conjoin
-                         , discard
+import Test.QuickCheck   ( arbitraryASCIIChar, counterexample, conjoin
+                         , discard, elements, forAll, forAllShrink, Gen
+                         , Property, suchThat, Testable, (===)
                          )
-import Data.Maybe        (isNothing, isJust)
-import Data.Char         (isLetter, isPrint, isSpace)
-import Data.List         (isSuffixOf)
+
 import Diamond (diamond)
 
 main :: IO ()

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -159,7 +159,7 @@ forAllDiamond p = forAll genDiamond $ maybe discard p
 shrinkNonAlphaChar :: Char -> String
 shrinkNonAlphaChar c =
   if isPrint c
-   then takeWhile (/= c) printableChars
-   else printableChars
+  then takeWhile (/= c) printableChars
+  else printableChars
   where
     printableChars = filter isPrint ['\0' .. '\127']

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -3,7 +3,7 @@
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
-import Test.QuickCheck   (Gen, oneof, forAll)
+import Test.QuickCheck   (Gen, elements, forAll)
 import Data.List         ((\\))
 import Data.Maybe        (isNothing)
 import Diamond (diamond)
@@ -115,6 +115,6 @@ cases = [ Case { description = "Degenerate case with a single 'A' row"
                }
         ]
 
-genNonAlphaChars :: Gen Char
+genNonAlphaChar :: Gen Char
 genNonAlphaChar = elements nonAlphaChars
   where nonAlphaChars = ['\0' .. '\127'] \\ (['A' .. 'Z'] ++ ['a' .. 'z'])

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -20,6 +20,9 @@ specs = describe "diamond" $ do
   it "Length of a diamond should be odd" $
     forAll genAlphaChar $ odd . length . fromMaybe [""] . diamond
 
+  it "Top and bottom of a diamond should be equal" $
+    forAll genAlphaChar $ topEqualToBottom . fromMaybe [""] . diamond
+
   for_ cases test
   where
     test Case{..} = it description assertion
@@ -124,3 +127,8 @@ genNonAlphaChar = elements nonAlphaChars
 
 genAlphaChar :: Gen Char
 genAlphaChar = choose ('A', 'Z')
+
+topEqualToBottom :: [String] -> Bool
+topEqualToBottom xs = take l xs == take l (reverse xs)
+  where
+    l = length xs `div` 2

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -3,9 +3,9 @@
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
-import Test.QuickCheck   (Gen, elements, forAll)
+import Test.QuickCheck   (Gen, elements, forAll, choose)
 import Data.List         ((\\))
-import Data.Maybe        (isNothing)
+import Data.Maybe        (isNothing, fromMaybe)
 import Diamond (diamond)
 
 main :: IO ()
@@ -16,6 +16,9 @@ specs = describe "diamond" $ do
   it "non-Alpha characters should produce `Nothing`" $
     forAll genNonAlphaChar $
       isNothing . diamond
+
+  it "Length of a diamond should be odd" $
+    forAll genAlphaChar $ odd . length . fromMaybe [""] . diamond
 
   for_ cases test
   where
@@ -118,3 +121,6 @@ cases = [ Case { description = "Degenerate case with a single 'A' row"
 genNonAlphaChar :: Gen Char
 genNonAlphaChar = elements nonAlphaChars
   where nonAlphaChars = ['\0' .. '\127'] \\ (['A' .. 'Z'] ++ ['a' .. 'z'])
+
+genAlphaChar :: Gen Char
+genAlphaChar = choose ('A', 'Z')

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -27,6 +27,9 @@ specs = describe "diamond" $ do
   it "Check the middle of the diamond is correct" $
     forAll genAlphaChar $ \c -> checkMiddle c . fromMaybe [""] $ diamond c
 
+  it "Check the dimensionality of the diamond is correct" $
+    forAll genAlphaChar $ \c -> checkCorrectDimensions c . fromMaybe [""] $ diamond c
+
   for_ cases test
   where
     test Case{..} = it description assertion
@@ -135,6 +138,9 @@ genAlphaChar = choose ('A', 'Z')
 topLength :: [String] -> Int
 topLength = (`div` 2) . length
 
+position :: Char -> Int
+position c = ord c - ord 'A'
+
 topEqualToBottom :: [String] -> Bool
 topEqualToBottom xs = take len xs == take len (reverse xs)
   where
@@ -143,8 +149,12 @@ topEqualToBottom xs = take len xs == take len (reverse xs)
 checkMiddle :: Char -> [String] -> Bool
 checkMiddle c xs = getMiddle xs == middle
   where
-    position = ord c - ord 'A'
     getMiddle ys = ys !! topLength ys
-    leftSide = c : replicate position ' '
+    leftSide = c : replicate (position c) ' '
     rightSide = tail . reverse $ leftSide
     middle = leftSide ++ rightSide
+
+checkCorrectDimensions :: Char -> [String] -> Bool
+checkCorrectDimensions c xs = length xs == dim && all ((== dim) . length) xs
+  where
+    dim = 2 * position c + 1

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -1,24 +1,24 @@
 {-# LANGUAGE RecordWildCards #-}
 
-import Data.Foldable       (for_)
-import Test.Hspec          (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner   (configFastFail, defaultConfig, hspecWith)
-import Test.QuickCheck     ( Gen
-                           , elements
-                           , forAll
-                           , forAllShrink
-                           , arbitraryASCIIChar
-                           , suchThat
-                           , Testable
-                           , Property
-                           , (===)
-                           , counterexample
-                           , conjoin
-                           , discard
-                           )
-import Data.Maybe          (isNothing, isJust)
-import Data.Char           (isLetter, isPrint, isSpace)
-import Data.List           (isSuffixOf)
+import Data.Foldable     (for_)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.QuickCheck   ( Gen
+                         , elements
+                         , forAll
+                         , forAllShrink
+                         , arbitraryASCIIChar
+                         , suchThat
+                         , Testable
+                         , Property
+                         , (===)
+                         , counterexample
+                         , conjoin
+                         , discard
+                         )
+import Data.Maybe        (isNothing, isJust)
+import Data.Char         (isLetter, isPrint, isSpace)
+import Data.List         (isSuffixOf)
 import Diamond (diamond)
 
 main :: IO ()

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -12,7 +12,6 @@ import Test.QuickCheck     ( Gen
                            , Testable
                            , Property
                            )
-import Data.List           (partition)
 import Data.Maybe          (isNothing, isJust, fromMaybe)
 import Data.Char           (ord, isLetter, isUpper, isPrint)
 import Control.Applicative (liftA2)
@@ -189,7 +188,7 @@ shrinkNonAlphaChar c = if isPrint c
                         then takeWhile (/= c) printableChars
                         else printableChars
   where
-    (printableChars, _) = partition isPrint ['\0' .. '\127']
+    printableChars = filter isPrint ['\0' .. '\127']
 
 checkFirstAndLastCharEq :: String -> Bool
 -- checkFirstAndLastCharEq xs = head letters == tail letters

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -14,7 +14,7 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = describe "diamond" $ do
   it "non-Alpha characters should produce `Nothing`" $
-    forAll genNonAlphaChars $
+    forAll genNonAlphaChar $
       isNothing . diamond
 
   for_ cases test

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -6,6 +6,7 @@ import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 import Test.QuickCheck   (Gen, elements, forAll, choose)
 import Data.List         ((\\))
 import Data.Maybe        (isNothing, fromMaybe)
+import Data.Char         (ord)
 import Diamond (diamond)
 
 main :: IO ()
@@ -22,6 +23,9 @@ specs = describe "diamond" $ do
 
   it "Top and bottom of a diamond should be equal" $
     forAll genAlphaChar $ topEqualToBottom . fromMaybe [""] . diamond
+
+  it "Check the middle of the diamond is correct" $
+    forAll genAlphaChar $ \c -> checkMiddle c . fromMaybe [""] $ diamond c
 
   for_ cases test
   where
@@ -128,7 +132,19 @@ genNonAlphaChar = elements nonAlphaChars
 genAlphaChar :: Gen Char
 genAlphaChar = choose ('A', 'Z')
 
+topLength :: [String] -> Int
+topLength = (`div` 2) . length
+
 topEqualToBottom :: [String] -> Bool
-topEqualToBottom xs = take l xs == take l (reverse xs)
+topEqualToBottom xs = take len xs == take len (reverse xs)
   where
-    l = length xs `div` 2
+    len = topLength xs
+
+checkMiddle :: Char -> [String] -> Bool
+checkMiddle c xs = getMiddle xs == middle
+  where
+    position = ord c - ord 'A'
+    getMiddle ys = ys !! topLength ys
+    leftSide = c : replicate position ' '
+    rightSide = tail . reverse $ leftSide
+    middle = leftSide ++ rightSide

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -16,6 +16,7 @@ specs = describe "diamond" $ do
   it "non-Alpha characters should produce `Nothing`" $
     forAll genNonAlphaChars $
       isNothing . diamond
+
   for_ cases test
   where
     test Case{..} = it description assertion

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -6,10 +6,9 @@ import Data.List         (isSuffixOf)
 import Data.Maybe        (isNothing, isJust)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
-import Test.QuickCheck   ( arbitraryASCIIChar, counterexample, conjoin
-                         , discard, elements, forAll, forAllShrink, Gen
-                         , Property, suchThat, Testable, (===)
-                         )
+import Test.QuickCheck   (arbitraryASCIIChar, counterexample, conjoin,
+                          discard, elements, forAll, forAllShrink, Gen,
+                          Property, suchThat, Testable, (===))
 
 import Diamond (diamond)
 

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -14,7 +14,7 @@ import Test.QuickCheck     ( Gen
                            , Property
                            )
 import Data.Maybe          (isNothing, isJust, fromMaybe)
-import Data.Char           (ord, isLetter, isPrint)
+import Data.Char           (ord, isLetter, isPrint, isSpace)
 import Data.List           (isSuffixOf)
 import Diamond (diamond)
 
@@ -46,7 +46,7 @@ specs = describe "diamond" $ do
     forAllDiamond $
       let headEqualsLast ys = not (null ys) && take 1 ys `isSuffixOf` ys
       in \case [] -> False
-               xs -> all headEqualsLast $ filter isLetter <$> xs
+               xs -> all headEqualsLast $ filter (not . isSpace) <$> xs
 
   for_ cases test
   where

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -13,6 +13,8 @@ import Test.QuickCheck     ( Gen
                            , Testable
                            , Property
                            , (===)
+                           , counterexample
+                           , conjoin
                            )
 import Data.Maybe          (isNothing, isJust, fromMaybe)
 import Data.Char           (ord, isLetter, isPrint, isSpace)
@@ -40,7 +42,13 @@ specs = describe "diamond" $ do
        in take halfRoundDown diamond === take halfRoundDown (reverse diamond)
 
   it "should have the same width and height" $
-    forAllCharDiamond checkCorrectDimensions
+    forAllDiamond $ \diamond ->
+      let sameHeightWidth idx row = counterexample
+            (concat [ "The length of row with index "
+                    , show idx
+                    , " is not equal to the height" ])
+            (length row === length diamond)
+      in conjoin $ zipWith sameHeightWidth [0..] diamond
 
   it "rows should start and end with the same letter" $
     forAllDiamond $
@@ -165,11 +173,6 @@ forAllCharDiamond p = forAll genDiamond $ uncurry p . fmap (fromMaybe [""])
 
 position :: Char -> Int
 position c = ord c - ord 'A'
-
-checkCorrectDimensions :: Char -> [String] -> Bool
-checkCorrectDimensions c xs = length xs == dim && all ((== dim) . length) xs
-  where
-    dim = 2 * position c + 1
 
 shrinkNonAlphaChar :: Char -> String
 shrinkNonAlphaChar c =

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -30,7 +30,7 @@ specs = describe "diamond" $ do
   it "should have equal top and bottom" $
     forAllDiamond $ \rows ->
       let halfRoundDown = length rows `div` 2
-       in take halfRoundDown rows === take halfRoundDown (reverse rows)
+      in take halfRoundDown rows === take halfRoundDown (reverse rows)
 
   it "should have the same width and height" $
     forAllDiamond $ \rows ->
@@ -44,7 +44,7 @@ specs = describe "diamond" $ do
   it "rows should start and end with the same letter" $
     forAllDiamond $
       let headEqualsLast row = not (null row) && take 1 row `isSuffixOf` row
-       in (&&) <$> not . null <*> all (headEqualsLast . filter (not . isSpace))
+      in (&&) <$> not . null <*> all (headEqualsLast . filter (not . isSpace))
 
   for_ cases test
   where

--- a/exercises/diamond/test/Tests.hs
+++ b/exercises/diamond/test/Tests.hs
@@ -147,7 +147,7 @@ genNonAlphaChar :: Gen Char
 genNonAlphaChar = arbitraryASCIIChar `suchThat` (not . isLetter)
 
 genAlphaChar :: Gen Char
-genAlphaChar = arbitraryASCIIChar `suchThat` isUpper
+genAlphaChar = elements ['A'..'Z']
 
 genDiamond :: Gen (Char, Maybe [String])
 genDiamond = do


### PR DESCRIPTION
Here is the initial implementation for property-based tests for the `diamond` exercise. For any non-letter character `diamond` should produce `Nothing`. I am very open to feedback as I would like to contribute to this project.

To do:
 
- [x] Read this PR carefully #735
- [x] Read this Issue carefully #600 