### PR TITLE
Update topics for core exercises in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,7 +23,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "booleans"
+        "booleans",
+        "guards"
       ]
     },
     {
@@ -33,7 +34,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "discriminated_unions"
+        "sum_types"
       ]
     },
     {
@@ -43,7 +44,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "strings"
+        "strings",
+        "higher_order_functions"
       ]
     },
     {
@@ -53,7 +55,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "strings"
+        "strings",
+        "guards"
       ]
     },
     {
@@ -63,7 +66,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "math",
+        "guards",
+        "recursion",
         "maybe",
         "number_theory"
       ]
@@ -75,6 +79,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+        "traversable",
         "either"
       ]
     },
@@ -85,6 +90,8 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
+        "data_structures",
+        "higher_order_functions",
         "either"
       ]
     },
@@ -283,7 +290,7 @@
       "unlocked_by": "bob",
       "difficulty": 3,
       "topics": [
-        "discriminated_unions",
+        "sum_types",
         "lists"
       ]
     },

--- a/config.json
+++ b/config.json
@@ -44,8 +44,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "strings",
-        "higher_order_functions"
+        "higher_order_functions",
+        "strings"
       ]
     },
     {
@@ -55,8 +55,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "strings",
-        "guards"
+        "guards",
+        "strings"
       ]
     },
     {
@@ -67,9 +67,9 @@
       "difficulty": 1,
       "topics": [
         "guards",
-        "recursion",
         "maybe",
-        "number_theory"
+        "number_theory",
+        "recursion"
       ]
     },
     {
@@ -79,8 +79,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "traversable",
-        "either"
+        "either",
+        "traversable"
       ]
     },
     {
@@ -91,8 +91,8 @@
       "difficulty": 2,
       "topics": [
         "data_structures",
-        "higher_order_functions",
-        "either"
+        "either",
+        "higher_order_functions"
       ]
     },
     {
@@ -290,8 +290,8 @@
       "unlocked_by": "bob",
       "difficulty": 3,
       "topics": [
-        "sum_types",
-        "lists"
+        "lists",
+        "sum_types"
       ]
     },
     {


### PR DESCRIPTION
Before continuing to restructure the Haskell core track in #798, this commit
adds more topics to the core exercises in particular. This should both make
the core track overview more indicative, and provide a better overview for
what to look for in replacement exercises.

The following topics were changed:

 - `leap`: Add "guards". One recommended set of solutions split the three
   predicates into each their guard. So while the exercise can be completed
   adequately without the use of guards, one can anticipate trying them out.

 - `space_age`: Replace "discriminated_unions" with "sum_types". This should
   sound less academic. Because "discriminated_unions" is also used in `yacht`,
   replace it there, too.

 - `pangram`: Add "higher_order_functions". There is a number of acceptable
   solution strategies that all have in common that explicit recursion is
   removed. One could also consider adding "predicates", but I've found it
   a little too general and not so indicative of what the exercise is about.

 - `bob`: Add "guards". This is probably the most significant core exercise
   wrt. the use of guards, since it contains so many different conditions.

 - `collatz-conjecture`: Add "guards" and "recursion". I thought about also
   applying "higher_order_functions" here, but since one popular solution
   here uses `iterate`, I thought more in the lines of recursion schemes.

 - `rna-transcription`: Add "traversable". Besides "either", the only point
   to make in this exercise is to use `traverse`. One could also consider
   "higher_order_functions" or "recursion" depending on how specific one
   wants to be.

 - `nucleotide-count`: Add "data_structures" and "higher_order_functions".
   This exercise can go in a lot of directions wrt. mentoring, cf. [1].
   But importantly, it deals with `Data.Map`, monadic error handling (so
   "either") and higher-order functions.

[1]: https://github.com/exercism/website-copy/blob/master/tracks/haskell/exercises/nucleotide-count/mentoring.md