### PR TITLE
Bank Account: extend hint with extra help

### DIFF
--- a/exercises/bank-account/.meta/hints.md
+++ b/exercises/bank-account/.meta/hints.md
@@ -14,3 +14,8 @@ The initial balance of the bank account should be 0.
 You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,
 newtype or type synonym.
+
+If you need help, here are some additional resources:
+
+- Read about [concurrency](https://en.wikipedia.org/wiki/Concurrent_Haskell) in Haskell.
+- Look into the [Software Transactional Memory](https://hackage.haskell.org/package/stm) package and its Transactional Variables.

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -43,6 +43,11 @@ You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,
 newtype or type synonym.
 
+If you need help, here are some additional resources:
+
+- Read about [concurrency](https://en.wikipedia.org/wiki/Concurrent_Haskell) in Haskell.
+- Look into the [Software Transactional Memory](https://hackage.haskell.org/package/stm) package and its Transactional Variables.
+
 
 
 ## Getting Started


### PR DESCRIPTION
The [Concurrent Haskell](https://en.wikipedia.org/wiki/Concurrent_Haskell) wikipedia page has an in-depth example of  `Control.Concurrent.STM` and should guide the user in the right direction.

The second point links to the [STM](https://hackage.haskell.org/package/stm) package to point the user to `TVar`. Maybe this is too explicit?

Closes #799 