### PR TITLE
forth: bump the version to 1.7.1 (no changes needed)

### DIFF
--- a/exercises/forth/package.yaml
+++ b/exercises/forth/package.yaml
@@ -1,5 +1,5 @@
 name: forth
-version: 1.7.0.11
+version: 1.7.1.12
 
 dependencies:
   - base


### PR DESCRIPTION
I checked with the changes:
https://github.com/exercism/problem-specifications/commit/75f4c0a8c86cd5140dc5e8f29ebbd6e728bc5025

There seem to be no typos in the haskell test descriptions, hence just a version bump