### PR TITLE
etl: bump the version to 2.0.1 (no changes needed)

### DIFF
--- a/exercises/etl/package.yaml
+++ b/exercises/etl/package.yaml
@@ -1,5 +1,5 @@
 name: etl
-version: 1.0.0.5
+version: 2.0.1.6
 
 dependencies:
   - base

--- a/exercises/etl/test/Tests.hs
+++ b/exercises/etl/test/Tests.hs
@@ -15,7 +15,7 @@ specs =
 
   describe "transform" $ do
 
-    it "a single letter" $
+    it "single letter" $
       transform (fromList [(1, "A")])
       `shouldBe` fromList [('a', 1)]
 


### PR DESCRIPTION
It seems that only a version bump is necessary.

Latest changes to this problem:

- exercism/problem-specifications#1536
- exercism/problem-specifications#1575