### PR TITLE
resistor-color-trio: Add exercise (with extensions)

### DIFF
--- a/config.json
+++ b/config.json
@@ -231,6 +231,17 @@
       ]
     },
     {
+      "slug": "resistor-color-trio",
+      "uuid": "946a2c88-fd0c-4dbc-a5cf-75ad9147e80c",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 3,
+      "topics": [
+        "strings",
+        "data_types"
+      ]
+    },
+    {
       "slug": "accumulate",
       "uuid": "5c5a9256-a55e-4bda-baf3-96d052732e11",
       "core": false,

--- a/config.json
+++ b/config.json
@@ -237,8 +237,8 @@
       "unlocked_by": "pangram",
       "difficulty": 3,
       "topics": [
-        "strings",
-        "data_types"
+        "data_types",
+        "strings"
       ]
     },
     {

--- a/exercises/resistor-color-trio/.meta/hints.md
+++ b/exercises/resistor-color-trio/.meta/hints.md
@@ -1,0 +1,24 @@
+## Hints
+
+You need to implement the functions `label` and `ohms`. You can use the
+provided signature for `label`, but don't let it restrict your creativity.
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+    ```haskell
+    import qualified Data.Text as T
+    import           Data.Text (Text)
+    ```
+
+- You can now write e.g. `label :: Resistor -> Text` and refer to `Data.Text` combinators as e.g. `T.pack`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html),
+
+This part is entirely optional.

--- a/exercises/resistor-color-trio/README.md
+++ b/exercises/resistor-color-trio/README.md
@@ -44,6 +44,32 @@ So an input of `"orange", "orange", "orange"` should return:
 
 > "33 kiloohms"
 
+## Hints
+
+You need to implement the functions `label` and `ohms`. You can use the
+provided signature for `label`, but don't let it restrict your creativity.
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Add `- text` to your list of dependencies in package.yaml.
+- Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+    ```haskell
+    import qualified Data.Text as T
+    import           Data.Text (Text)
+    ```
+
+- You can now write e.g. `label :: Resistor -> Text` and refer to `Data.Text` combinators as e.g. `T.pack`.
+- Look up the documentation for [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html),
+
+This part is entirely optional.
+
+
 
 ## Getting Started
 

--- a/exercises/resistor-color-trio/README.md
+++ b/exercises/resistor-color-trio/README.md
@@ -1,0 +1,105 @@
+# Resistor Color Trio
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_. For this exercise, you need to know only three things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+  To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+- Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take 3 colors as input, and outputs the correct value, in ohms.
+  The color bands are encoded as follows:
+
+* Black: 0
+* Brown: 1
+* Red: 2
+* Orange: 3
+* Yellow: 4
+* Green: 5
+* Blue: 6
+* Violet: 7
+* Grey: 8
+* White: 9
+
+In `resistor-color duo` you decoded the first two colors. For instance: orange-orange got the main value `33`.
+The third color stands for how many zeros need to be added to the main value. The main value plus the zeros gives us a value in ohms.
+For the exercise it doesn't matter what ohms really are.
+For example:
+
+- orange-orange-black would be 33 and no zeros, which becomes 33 ohms.
+- orange-orange-red would be 33 and 2 zeros, which becomes 3300 ohms.
+- orange-orange-orange would be 33 and 3 zeros, which becomes 33000 ohms.
+
+(If Math is your thing, you may want to think of the zeros as exponents of 10. If Math is not your thing, go with the zeros. It really is the same thing, just in plain English instead of Math lingo.)
+
+This exercise is about translating the colors into a label:
+
+> "... ohms"
+
+So an input of `"orange", "orange", "black"` should return:
+
+> "33 ohms"
+
+When we get more than a thousand ohms, we say "kiloohms". That's similar to saying "kilometer" for 1000 meters, and "kilograms" for 1000 grams.
+So an input of `"orange", "orange", "orange"` should return:
+
+> "33 kiloohms"
+
+
+## Getting Started
+
+Please refer to the [installation](https://exercism.io/tracks/haskell/installation)
+and [learning](https://exercism.io/tracks/haskell/learning) help pages.
+
+## Running the tests
+
+To run the test suite, execute the following command:
+
+```bash
+stack test
+```
+
+#### If you get an error message like this...
+
+```
+No .cabal file found in directory
+```
+
+You are probably running an old stack version and need
+to upgrade it.
+
+#### Otherwise, if you get an error message like this...
+
+```
+No compiler found, expected minor version match with...
+Try running "stack setup" to install the correct GHC...
+```
+
+Just do as it says and it will download and install
+the correct compiler version:
+
+```bash
+stack setup
+```
+
+## Running *GHCi*
+
+If you want to play with your solution in GHCi, just run the command:
+
+```bash
+stack ghci
+```
+
+## Feedback, Issues, Pull Requests
+
+The [exercism/haskell](https://github.com/exercism/haskell) repository on
+GitHub is the home for all of the Haskell exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue.  We'll do our best to help you!
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1549](https://github.com/exercism/problem-specifications/issues/1549)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color-trio/examples/success-standard/package.yaml
+++ b/exercises/resistor-color-trio/examples/success-standard/package.yaml
@@ -1,0 +1,16 @@
+name: resistor-color-trio
+
+dependencies:
+  - base
+
+library:
+  exposed-modules: ResistorColors
+  source-dirs: src
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - resistor-color-trio
+      - hspec

--- a/exercises/resistor-color-trio/examples/success-standard/src/ResistorColors.hs
+++ b/exercises/resistor-color-trio/examples/success-standard/src/ResistorColors.hs
@@ -12,10 +12,10 @@ data Color =
   | Violet
   | Grey
   | White
-  deriving (Eq, Show, Enum, Bounded)
+  deriving (Show, Enum, Bounded)
 
 newtype Resistor = Resistor { bands :: (Color, Color, Color) }
-  deriving (Eq, Show)
+  deriving Show
 
 label :: Resistor -> String
 label resistor

--- a/exercises/resistor-color-trio/examples/success-standard/src/ResistorColors.hs
+++ b/exercises/resistor-color-trio/examples/success-standard/src/ResistorColors.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE NumDecimals #-}
 module ResistorColors (Color(..), Resistor(..), label, ohms) where
 
+import Data.Ratio (Ratio, numerator, denominator)
+
 data Color =
     Black
   | Brown
@@ -19,18 +21,24 @@ newtype Resistor = Resistor { bands :: (Color, Color, Color) }
 
 label :: Resistor -> String
 label resistor
-  | ohms' < kilo = show ohms'               ++ " ohms"
-  | ohms' < mega = show (ohms' `quot` kilo) ++ " kiloohms"
-  | ohms' < giga = show (ohms' `quot` mega) ++ " megaohms"
-  | otherwise    = show (ohms' `quot` giga) ++ " gigaohms"
+  | ohms' < kilo = showOhms ohms'          ++ " ohms"
+  | ohms' < mega = showOhms (ohms' / kilo) ++ " kiloohms"
+  | ohms' < giga = showOhms (ohms' / mega) ++ " megaohms"
+  | otherwise    = showOhms (ohms' / giga) ++ " gigaohms"
   where
-    ohms' = ohms resistor
+    ohms' = realToFrac (ohms resistor)
+
+showOhms :: Ratio Int -> String
+showOhms ohms' =
+  if denominator ohms' == 1
+  then show (numerator ohms')
+  else show (realToFrac ohms' :: Double)
 
 ohms :: Resistor -> Int
 ohms (Resistor (a, b, e)) =
   (10 * fromEnum a + fromEnum b) * 10 ^ fromEnum e
 
-kilo, mega, giga :: Int
+kilo, mega, giga :: Num n => n
 kilo = 1e3
 mega = 1e6
 giga = 1e9

--- a/exercises/resistor-color-trio/examples/success-standard/src/ResistorColors.hs
+++ b/exercises/resistor-color-trio/examples/success-standard/src/ResistorColors.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE NumDecimals #-}
+module ResistorColors (Color(..), Resistor(..), label, ohms) where
+
+data Color =
+    Black
+  | Brown
+  | Red
+  | Orange
+  | Yellow
+  | Green
+  | Blue
+  | Violet
+  | Grey
+  | White
+  deriving (Eq, Show, Enum, Bounded)
+
+newtype Resistor = Resistor { bands :: (Color, Color, Color) }
+  deriving (Eq, Show)
+
+label :: Resistor -> String
+label resistor
+  | ohms' < kilo = show ohms'               ++ " ohms"
+  | ohms' < mega = show (ohms' `quot` kilo) ++ " kiloohms"
+  | ohms' < giga = show (ohms' `quot` mega) ++ " megaohms"
+  | otherwise    = show (ohms' `quot` giga) ++ " gigaohms"
+  where
+    ohms' = ohms resistor
+
+ohms :: Resistor -> Int
+ohms (Resistor (a, b, e)) =
+  (10 * fromEnum a + fromEnum b) * 10 ^ fromEnum e
+
+kilo, mega, giga :: Int
+kilo = 1e3
+mega = 1e6
+giga = 1e9

--- a/exercises/resistor-color-trio/examples/success-text/package.yaml
+++ b/exercises/resistor-color-trio/examples/success-text/package.yaml
@@ -1,0 +1,17 @@
+name: resistor-color-trio
+
+dependencies:
+  - base
+  - text
+
+library:
+  exposed-modules: ResistorColors
+  source-dirs: src
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - resistor-color-trio
+      - hspec

--- a/exercises/resistor-color-trio/examples/success-text/src/ResistorColors.hs
+++ b/exercises/resistor-color-trio/examples/success-text/src/ResistorColors.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NumDecimals #-}
+module ResistorColors (Color(..), Resistor(..), label, ohms) where
+
+import Data.Text (Text, pack)
+
+data Color =
+    Black
+  | Brown
+  | Red
+  | Orange
+  | Yellow
+  | Green
+  | Blue
+  | Violet
+  | Grey
+  | White
+  deriving (Eq, Show, Enum, Bounded)
+
+newtype Resistor = Resistor { bands :: (Color, Color, Color) }
+  deriving (Eq, Show)
+
+label :: Resistor -> Text
+label resistor
+  | ohms' < kilo = tshow ohms'               <> " ohms"
+  | ohms' < mega = tshow (ohms' `quot` kilo) <> " kiloohms"
+  | ohms' < giga = tshow (ohms' `quot` mega) <> " megaohms"
+  | otherwise    = tshow (ohms' `quot` giga) <> " gigaohms"
+  where
+    ohms' = ohms resistor
+
+tshow :: Show a => a -> Text
+tshow = pack . show
+
+ohms :: Resistor -> Int
+ohms (Resistor (a, b, e)) =
+  (10 * fromEnum a + fromEnum b) * 10 ^ fromEnum e
+
+kilo, mega, giga :: Int
+kilo = 1e3
+mega = 1e6
+giga = 1e9

--- a/exercises/resistor-color-trio/examples/success-text/src/ResistorColors.hs
+++ b/exercises/resistor-color-trio/examples/success-text/src/ResistorColors.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NumDecimals #-}
 module ResistorColors (Color(..), Resistor(..), label, ohms) where
 
+import Data.Ratio (Ratio, numerator, denominator)
 import Data.Text (Text, pack)
 
 data Color =
@@ -22,21 +23,27 @@ newtype Resistor = Resistor { bands :: (Color, Color, Color) }
 
 label :: Resistor -> Text
 label resistor
-  | ohms' < kilo = tshow ohms'               <> " ohms"
-  | ohms' < mega = tshow (ohms' `quot` kilo) <> " kiloohms"
-  | ohms' < giga = tshow (ohms' `quot` mega) <> " megaohms"
-  | otherwise    = tshow (ohms' `quot` giga) <> " gigaohms"
+  | ohms' < kilo = showOhms ohms'          <> " ohms"
+  | ohms' < mega = showOhms (ohms' / kilo) <> " kiloohms"
+  | ohms' < giga = showOhms (ohms' / mega) <> " megaohms"
+  | otherwise    = showOhms (ohms' / giga) <> " gigaohms"
   where
-    ohms' = ohms resistor
+    ohms' = realToFrac (ohms resistor)
 
 tshow :: Show a => a -> Text
 tshow = pack . show
+
+showOhms :: Ratio Int -> Text
+showOhms ohms' =
+  if denominator ohms' == 1
+  then tshow (numerator ohms')
+  else tshow (realToFrac ohms' :: Double)
 
 ohms :: Resistor -> Int
 ohms (Resistor (a, b, e)) =
   (10 * fromEnum a + fromEnum b) * 10 ^ fromEnum e
 
-kilo, mega, giga :: Int
+kilo, mega, giga :: Num n => n
 kilo = 1e3
 mega = 1e6
 giga = 1e9

--- a/exercises/resistor-color-trio/examples/success-text/src/ResistorColors.hs
+++ b/exercises/resistor-color-trio/examples/success-text/src/ResistorColors.hs
@@ -15,10 +15,10 @@ data Color =
   | Violet
   | Grey
   | White
-  deriving (Eq, Show, Enum, Bounded)
+  deriving (Show, Enum, Bounded)
 
 newtype Resistor = Resistor { bands :: (Color, Color, Color) }
-  deriving (Eq, Show)
+  deriving Show
 
 label :: Resistor -> Text
 label resistor

--- a/exercises/resistor-color-trio/package.yaml
+++ b/exercises/resistor-color-trio/package.yaml
@@ -1,0 +1,21 @@
+name: resistor-color-trio
+version: 1.0.0.0
+
+dependencies:
+  - base
+
+library:
+  exposed-modules: ResistorColors
+  source-dirs: src
+  ghc-options: -Wall
+  # dependencies:
+  # - foo       # List here the packages you
+  # - bar       # want to use in your solution.
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - resistor-color-trio
+      - hspec

--- a/exercises/resistor-color-trio/src/ResistorColors.hs
+++ b/exercises/resistor-color-trio/src/ResistorColors.hs
@@ -1,0 +1,23 @@
+module ResistorColors (Color(..), Resistor(..), label, ohms) where
+
+data Color =
+    Black
+  | Brown
+  | Red
+  | Orange
+  | Yellow
+  | Green
+  | Blue
+  | Violet
+  | Grey
+  | White
+  deriving (Eq, Show, Enum, Bounded)
+
+newtype Resistor = Resistor { bands :: (Color, Color, Color) }
+  deriving (Eq, Show)
+
+label :: Resistor -> String
+label resistor = error "You need to implement this function."
+
+ohms :: Resistor -> Int
+ohms resistor = error "You need to implement this function."

--- a/exercises/resistor-color-trio/src/ResistorColors.hs
+++ b/exercises/resistor-color-trio/src/ResistorColors.hs
@@ -11,10 +11,10 @@ data Color =
   | Violet
   | Grey
   | White
-  deriving (Eq, Show, Enum, Bounded)
+  deriving (Show, Enum, Bounded)
 
 newtype Resistor = Resistor { bands :: (Color, Color, Color) }
-  deriving (Eq, Show)
+  deriving Show
 
 label :: Resistor -> String
 label resistor = error "You need to implement this function."

--- a/exercises/resistor-color-trio/stack.yaml
+++ b/exercises/resistor-color-trio/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-14.7

--- a/exercises/resistor-color-trio/test/Tests.hs
+++ b/exercises/resistor-color-trio/test/Tests.hs
@@ -39,6 +39,7 @@ cases = [ Case { input         = Resistor (Black, Black, Black)
                , expectedLabel = "0 ohms"
                , expectedOhms  = 0
                }
+
         , Case { input         = Resistor (Black, Yellow, Black)
                , expectedLabel = "4 ohms"
                , expectedOhms  = 4
@@ -63,6 +64,7 @@ cases = [ Case { input         = Resistor (Black, Black, Black)
                , expectedLabel = "970 kiloohms"
                , expectedOhms  = 970e3
                }
+
         , Case { input         = Resistor (White, Black, Green)
                , expectedLabel = "9 megaohms"
                , expectedOhms  = 9e6

--- a/exercises/resistor-color-trio/test/Tests.hs
+++ b/exercises/resistor-color-trio/test/Tests.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NumDecimals #-}
+
+import Data.Foldable     (for_)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Data.String       (fromString)
+
+import ResistorColors (Color(..), Resistor(..), label, ohms)
+
+main :: IO ()
+main = hspecWith defaultConfig {configFastFail = True} specs
+
+specs :: Spec
+specs = do
+  describe "label" $ for_ cases testLabel
+  describe "ohms" $ for_ cases testOhms
+  where
+    testLabel Case{..} = it (description input) $
+      label input `shouldBe` fromString expectedLabel
+      where
+        description Resistor{..} =
+          show bands ++ " should give " ++ expectedLabel
+
+    testOhms Case{..} = it (description input) $
+      ohms input `shouldBe` expectedOhms
+      where
+        description Resistor{..} =
+          show bands ++ " should give " ++ show expectedOhms
+
+data Case = Case { input         :: Resistor
+                 , expectedLabel :: String
+                 , expectedOhms  :: Int
+                 }
+
+cases :: [Case]
+cases = [ Case { input         = Resistor (Black, Black, Black)
+               , expectedLabel = "0 ohms"
+               , expectedOhms  = 0
+               }
+        , Case { input         = Resistor (Black, Yellow, Black)
+               , expectedLabel = "4 ohms"
+               , expectedOhms  = 4
+               }
+        , Case { input         = Resistor (Grey, Orange, Black)
+               , expectedLabel = "83 ohms"
+               , expectedOhms  = 83
+               }
+        , Case { input         = Resistor (Blue, Grey, Brown)
+               , expectedLabel = "680 ohms"
+               , expectedOhms  = 680
+               }
+        , Case { input         = Resistor (Red, Black, Red)
+               , expectedLabel = "2 kiloohms"
+               , expectedOhms  = 2e3
+               }
+        , Case { input         = Resistor (Green, Brown, Orange)
+               , expectedLabel = "51 kiloohms"
+               , expectedOhms  = 51e3
+               }
+        , Case { input         = Resistor (White, Violet, Yellow)
+               , expectedLabel = "970 kiloohms"
+               , expectedOhms  = 970e3
+               }
+        , Case { input         = Resistor (White, Black, Green)
+               , expectedLabel = "9 megaohms"
+               , expectedOhms  = 9e6
+               }
+        , Case { input         = Resistor (Brown, Grey, Blue)
+               , expectedLabel = "18 megaohms"
+               , expectedOhms  = 18e6
+               }
+        , Case { input         = Resistor (Red, Violet, Violet)
+               , expectedLabel = "270 megaohms"
+               , expectedOhms  = 270e6
+               }
+        , Case { input         = Resistor (Yellow, Black, Grey)
+               , expectedLabel = "4 gigaohms"
+               , expectedOhms  = 4e9
+               }
+        , Case { input         = Resistor (Orange, Blue, White)
+               , expectedLabel = "36 gigaohms"
+               , expectedOhms  = 36e9
+               }
+        {-
+           -- The following tests are commented out to decrease the
+           -- complexity of the exercise. Students may choose freely
+           -- to include them or not.
+        , Case { input         = Resistor (Brown, Red, Red)
+               , expectedLabel = "1.2 kiloohms"
+               , expectedOhms  = 1.2e3
+               }
+        , Case { input         = Resistor (Orange, Yellow, Green)
+               , expectedLabel = "3.4 megaohms"
+               , expectedOhms  = 3.4e6
+               }
+        , Case { input         = Resistor (Green, Blue, Grey)
+               , expectedLabel = "5.6 gigaohms"
+               , expectedOhms  = 5.6e9
+               }
+        -}
+        ]
+

--- a/exercises/resistor-color-trio/test/Tests.hs
+++ b/exercises/resistor-color-trio/test/Tests.hs
@@ -103,4 +103,3 @@ cases = [ Case { input         = Resistor (Black, Black, Black)
                }
         -}
         ]
-


### PR DESCRIPTION
This adds the exercise from exercism/problem-specifications#1551.

In addition to the canonical exercise, this implementation extends:
 - Add a "zero" test case (Black, Black, Black).

 - Add a `Data.Text` hint in `.meta/hints.md`.

 - Export both a `label` function *and* an `ohms` function: While the
   exercise is mainly about printing a formatted string, this nudges
   the student towards separating print and calculate.

 - For totality, since `Resistor` allows expressing resistors in the
   megaohm and gigaohm ranges, extend the exercise so that the correct
   unit beyond kiloohms are returned.

 - Extended unit tests are added, and coverage is described as such:

   Canonical tests are marked with 'x'.
   Extended tests are marked with 'y'.
   Optional (commented out) tests are marked with 'z'.

   ```
   Color       1, 2      3
   -------------------------
   Black       xyyyyy    xyy
   Brown       xyz       x
   Red         xyz       xz
   Orange      xxz       x
   Yellow      xyz       x
   Green       xyz       yz
   Blue        xyz       y
   Violet      xy        y
   Grey        xy        yz
   White       yy        y
   ```

   The over-representation of Black is partly caused by the fact that
   canonical and extended tests avoid edge cases like "4.7 kiloohms".
   There is some didactial point in incremental improvements, and as
   such, canonical and extended tests partially validates solutions.

   Optional (commented out) tests make the exercise considerably more
   difficult, so they are accompanied with a disclaimer that students
   may choose freely to include them or not.

   This way, students who are oblivious to the edge cases will not be
   aware of them, and students who are not (either by thinking or by
   inspecting the unit tests) will be able to choose.