### PR TITLE
upgrade pangram tests to 2.0.0

### DIFF
--- a/exercises/pangram/package.yaml
+++ b/exercises/pangram/package.yaml
@@ -1,5 +1,5 @@
 name: pangram
-version: 1.4.1.11
+version: 2.0.0.12
 
 dependencies:
   - base

--- a/exercises/pangram/test/Tests.hs
+++ b/exercises/pangram/test/Tests.hs
@@ -22,58 +22,58 @@ data Case = Case { description :: String
                  }
 
 cases :: [Case]
-cases = [ Case { description = "sentence empty"
+cases = [ Case { description = "with empty sentence"
                , input       = ""
                , expected    = False
                }
-        , Case { description = "recognizes a perfect lower case pangram"
+        , Case { description = "with perfect lower case"
                , input       = "abcdefghijklmnopqrstuvwxyz"
                , expected    = True
                }
-        , Case { description = "pangram with only lower case"
+        , Case { description = "with only lower case"
                , input       = "the quick brown fox jumps over the lazy dog"
                , expected    = True
                }
-        , Case { description = "missing character 'x'"
+        , Case { description = "with missing character 'x'"
                , input       = "a quick movement of the enemy will jeopardize five gunboats"
                , expected    = False
                }
-        , Case { description = "another missing character, e.g. 'h'"
+        , Case { description = "with missing character 'h'"
                , input       = "five boxing wizards jump quickly at it"
                , expected    = False
                }
-        , Case { description = "pangram with underscores"
+        , Case { description = "with underscores"
                , input       = "the_quick_brown_fox_jumps_over_the_lazy_dog"
                , expected    = True
                }
-        , Case { description = "pangram with numbers"
+        , Case { description = "with numbers"
                , input       = "the 1 quick brown fox jumps over the 2 lazy dogs"
                , expected    = True
                }
-        , Case { description = "missing letters replaced by numbers"
+        , Case { description = "with missing letters replaced by numbers"
                , input       = "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog"
                , expected    = False
                }
-        , Case { description = "pangram with mixed case and punctuation"
+        , Case { description = "with mixed case and punctuation"
                , input       = "\"Five quacking Zephyrs jolt my wax bed.\""
                , expected    = True
                }
-        , Case { description = "upper and lower case versions of the same character should not be counted separately"
+        , Case { description = "with mixed case"
                , input       = "the quick brown fox jumps over with lazy FX"
                , expected    = False
                }
-        , Case { description = "missing character with additional non-ascii letters"
+        , Case { description = "with missing character and non-ascii letters"
                , input       = "abcdefghijklmnopqrstuvwxyÃ"
                , expected    = False
                }
-        , Case { description = "pangram with additional non-ascii letters"
+        , Case { description = "with additional non-ascii letters"
                , input       = "abcdefghijklmnopqrstuvwxyzÃ"
                , expected    = True
                }
 
         {-
         -- The following test can be enabled for String-based solutions:
-        , Case { description = "determine pangram by terminating as soon as all letters have occurred"
+        , Case { description = "with termination as soon as all letters have occurred"
                , input       = "abcdefghijklmnopqrstuvwxyz" ++ [undefined]
                , expected    = True
                }


### PR DESCRIPTION
This PR updates the `pangram` tests original mentioned in https://github.com/exercism/haskell/issues/852

I found this commit https://github.com/exercism/problem-specifications/commit/f68b632f2578d9969074657d764b32f61f53c008 describing the recent changes to the tests. It seems that the descriptions are the only thing that changed. Is the goal to match the descriptions? Or match the canonical tests described in the specifications?