### PR TITLE
robot-simulator: bump version to 3.2.0 and update test titles

### DIFF
--- a/exercises/robot-simulator/package.yaml
+++ b/exercises/robot-simulator/package.yaml
@@ -1,5 +1,5 @@
 name: robot-simulator
-version: 3.1.0.7
+version: 3.2.0.8
 
 dependencies:
   - base

--- a/exercises/robot-simulator/test/Tests.hs
+++ b/exercises/robot-simulator/test/Tests.hs
@@ -26,12 +26,12 @@ specs = do
     -- The function described by the reference file
     -- as `create` is called `mkRobot` in this track.
 
-      it "A robot is created with a position and a direction" $ do
+      it "Create robot at origin facing north" $ do
         let robot = mkRobot North (0, 0)
         coordinates robot `shouldBe` (0, 0)
         bearing     robot `shouldBe` North
 
-      it "Negative positions are allowed" $ do
+      it "Create robot at negative position facing south" $ do
         let robot = mkRobot South (-1, -1)
         coordinates robot `shouldBe` (-1, -1)
         bearing     robot `shouldBe` South
@@ -44,21 +44,21 @@ specs = do
             it "shouldn't change position" $
               coordinates (move robot inst) `shouldBe` (0, 0)
 
-    describe "turning right rotates the robot's direction 90 degrees clockwise" $ do
+    describe "Rotating clockwise" $ do
       let rightTest = turnTest "R"
       rightTest North East
       rightTest East South
       rightTest South West
       rightTest West North
 
-    describe "turning left rotates the robot's direction 90 degrees counter-clockwise" $ do
+    describe "Rotating counter-clockwise" $ do
       let leftTest = turnTest "L"
       leftTest North West
       leftTest West South
       leftTest South East
       leftTest East North
 
-    describe "advancing" $ do
+    describe "Moving forward one" $ do
       let dir `from` pos = move (mkRobot dir pos) "A"
       let test desc dir pos =
             describe (show dir ++ " from " ++ show pos) $ do
@@ -67,31 +67,31 @@ specs = do
               it desc $
                 coordinates (dir `from` (0, 0)) `shouldBe` pos
 
-      test "increases the y coordinate one when facing north" North (0, 1)
-      test "decreases the y coordinate by one when facing south" South (0, -1)
-      test "increases the x coordinate by one when facing east" East (1, 0)
-      test "decreases the x coordinate by one when facing west" West (-1, 0)
+      test "facing north increments Y" North (0, 1)
+      test "facing south decrements Y" South (0, -1)
+      test "facing east increments X" East (1, 0)
+      test "facing west decrements X" West (-1, 0)
 
-    describe "move" $ do
+    describe "Follow series of instructions" $ do
 
       let simulation pos dir = move (mkRobot dir pos)
 
-      it "instructions to move east and north from README" $ do
+      it "moving east and north from README" $ do
         let robot = simulation (7, 3) North "RAALAL"
         coordinates robot `shouldBe` (9, 4)
         bearing     robot `shouldBe` West
 
-      it "instructions to move west and north" $ do
+      it "moving west and north" $ do
         let robot = simulation (0, 0) North "LAAARALA"
         coordinates robot `shouldBe` (-4, 1)
         bearing     robot `shouldBe` West
 
-      it "instructions to move west and south" $ do
+      it "moving west and south" $ do
         let robot = simulation (2, -7) East "RRAAAAALA"
         coordinates robot `shouldBe` (-3, -8)
         bearing     robot `shouldBe` South
 
-      it "instructions to move east and north" $ do
+      it "moving east and north" $ do
         let robot = simulation (8, 4) South "LAAARRRALLLL"
         coordinates robot `shouldBe` (11, 5)
         bearing     robot `shouldBe` North


### PR DESCRIPTION
Comparing the current tests (3.1.0.7) with the current canonical
version for this exercise (3.2.0), the descriptions and titles have
changed in the PR exercism/problem-specifications#1525