### PR TITLE
Allow for use of Data.Text with twelve-days exercise

### DIFF
--- a/exercises/twelve-days/.meta/hints.md
+++ b/exercises/twelve-days/.meta/hints.md
@@ -1,0 +1,34 @@
+## Hints
+
+You need to implement the `recite` function which outputs the lyrics to
+'The Twelve Days of Christmas'. You can use the provided signature
+if you are unsure about the types, but don't let it restrict your creativity.
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- read about [string types](https://haskell-lang.org/tutorial/string-types) in
+  Haskell.
+- add `- text` to your list of dependencies in package.yaml.
+- import `Data.Text` in [the following
+  way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+```haskell
+import qualified Data.Text as T
+import           Data.Text (Text)
+```
+
+- write e.g. `recite :: Int -> Int -> [Text]` and refer to
+  `Data.Text` combinators as e.g. `T.pack`.
+- look up the documentation for
+  [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+- replace all occurrences of `String` with `Text` in TwelveDays.hs, i.e.:
+
+```haskell
+recite :: Int -> Int -> [Text]
+```
+
+This part is entirely optional.

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -28,6 +28,42 @@ On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, 
 On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
 ```
 
+## Hints
+
+You need to implement the `recite` function which outputs the lyrics to
+'The Twelve Days of Christmas'. You can use the provided signature
+if you are unsure about the types, but don't let it restrict your creativity.
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- read about [string types](https://haskell-lang.org/tutorial/string-types) in
+  Haskell.
+- add `- text` to your list of dependencies in package.yaml.
+- import `Data.Text` in [the following
+  way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+```haskell
+import qualified Data.Text as T
+import           Data.Text (Text)
+```
+
+- write e.g. `recite :: Int -> Int -> [Text]` and refer to
+  `Data.Text` combinators as e.g. `T.pack`.
+- look up the documentation for
+  [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+- replace all occurrences of `String` with `Text` in TwelveDays.hs, i.e.:
+
+```haskell
+recite :: Int -> Int -> [Text]
+```
+
+This part is entirely optional.
+
+
 
 ## Getting Started
 

--- a/exercises/twelve-days/package.yaml
+++ b/exercises/twelve-days/package.yaml
@@ -1,5 +1,5 @@
 name: twelve-days
-version: 1.2.0.4
+version: 1.2.0.5
 
 dependencies:
   - base

--- a/exercises/twelve-days/test/Tests.hs
+++ b/exercises/twelve-days/test/Tests.hs
@@ -3,6 +3,7 @@
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Data.String       (fromString)
 
 import TwelveDays (recite)
 
@@ -14,7 +15,7 @@ specs = describe "responseFor" $ for_ cases test
   where
       test Case{..} = it description assertion
         where
-          assertion = recite start stop `shouldBe` expected
+          assertion = recite start stop `shouldBe` fromString <$> expected
 
 data Case = Case { description :: String
                  , start       :: Int


### PR DESCRIPTION
This allows students to use `Data.Text` to solve the `twelve-days` exercise.

See #841 