### PR TITLE
Allow for use of Data.Text on rotational-cipher exercise

### DIFF
--- a/exercises/rotational-cipher/.meta/hints.md
+++ b/exercises/rotational-cipher/.meta/hints.md
@@ -1,0 +1,33 @@
+## Hints
+￼
+￼You need to implement the `rotate` function, which takes an `Int` and a `String`, and then encodes it using an rotational cipher.
+￼You can use the provided signature ￼if you are unsure about the types, but don't let it restrict your creativity.
+￼
+￼This exercise works with textual data. For historical reasons, Haskell's
+￼`String` type is synonymous with `[Char]`, a list of characters. For more
+￼efficient handling of textual data, the `Text` type can be used.
+￼
+￼As an optional extension to this exercise, you can
+￼
+￼- read about [string types](https://haskell-lang.org/tutorial/string-types) in
+￼  Haskell.
+￼- add `- text` to your list of dependencies in package.yaml.
+￼- import `Data.Text` in [the following
+￼  way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+￼
+￼```haskell
+￼import qualified Data.Text as T
+￼import           Data.Text (Text)
+￼```
+
+￼- use the `Text` type e.g. `rotate :: Int -> Text -> Text` and refer to
+￼  `Data.Text` combinators as e.g. `T.pack`.
+￼- look up the documentation for
+￼  [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+￼- replace all occurrences of `String` with `Text` in RotationalCipher.hs, i.e.:
+￼
+￼```haskell
+rotate :: Int -> Text -> Text
+￼```
+￼
+￼This part is entirely optional.

--- a/exercises/rotational-cipher/.meta/hints.md
+++ b/exercises/rotational-cipher/.meta/hints.md
@@ -1,33 +1,34 @@
 ## Hints
-￼
-￼You need to implement the `rotate` function, which takes an `Int` and a `String`, and then encodes it using an rotational cipher.
-￼You can use the provided signature ￼if you are unsure about the types, but don't let it restrict your creativity.
-￼
-￼This exercise works with textual data. For historical reasons, Haskell's
-￼`String` type is synonymous with `[Char]`, a list of characters. For more
-￼efficient handling of textual data, the `Text` type can be used.
-￼
-￼As an optional extension to this exercise, you can
-￼
-￼- read about [string types](https://haskell-lang.org/tutorial/string-types) in
-￼  Haskell.
-￼- add `- text` to your list of dependencies in package.yaml.
-￼- import `Data.Text` in [the following
-￼  way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
-￼
-￼```haskell
-￼import qualified Data.Text as T
-￼import           Data.Text (Text)
-￼```
 
-￼- use the `Text` type e.g. `rotate :: Int -> Text -> Text` and refer to
-￼  `Data.Text` combinators as e.g. `T.pack`.
-￼- look up the documentation for
-￼  [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
-￼- replace all occurrences of `String` with `Text` in RotationalCipher.hs, i.e.:
-￼
-￼```haskell
+You need to implement the `rotate` function, which takes an `Int` and a `String`, and then encodes it using an rotational cipher.
+You can use the provided signature if you are unsure about the types, but don't let it restrict your creativity.
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- read about [string types](https://haskell-lang.org/tutorial/string-types) in
+  Haskell.
+- add `- text` to your list of dependencies in package.yaml.
+- import `Data.Text` in [the following
+  way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+```haskell
+import qualified Data.Text as T
+import           Data.Text (Text)
+```
+
+- use the `Text` type e.g. `rotate :: Int -> Text -> Text` and refer to
+  `Data.Text` combinators as e.g. `T.pack`.
+- look up the documentation for
+  [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+- replace all occurrences of `String` with `Text` in RotationalCipher.hs, i.e.:
+
+```haskell
 rotate :: Int -> Text -> Text
-￼```
-￼
-￼This part is entirely optional.
+```
+
+This part is entirely optional.
+

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -31,38 +31,41 @@ Ciphertext is written out in the same formatting as the input including spaces a
 - ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
 
 ## Hints
-￼
-￼You need to implement the `rotate` function, which takes an `Int` and a `String`, and then encodes it using an rotational cipher.
-￼You can use the provided signature ￼if you are unsure about the types, but don't let it restrict your creativity.
-￼
-￼This exercise works with textual data. For historical reasons, Haskell's
-￼`String` type is synonymous with `[Char]`, a list of characters. For more
-￼efficient handling of textual data, the `Text` type can be used.
-￼
-￼As an optional extension to this exercise, you can
-￼
-￼- read about [string types](https://haskell-lang.org/tutorial/string-types) in
-￼  Haskell.
-￼- add `- text` to your list of dependencies in package.yaml.
-￼- import `Data.Text` in [the following
-￼  way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
-￼
-￼```haskell
-￼import qualified Data.Text as T
-￼import           Data.Text (Text)
-￼```
 
-￼- use the `Text` type e.g. `rotate :: Int -> Text -> Text` and refer to
-￼  `Data.Text` combinators as e.g. `T.pack`.
-￼- look up the documentation for
-￼  [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
-￼- replace all occurrences of `String` with `Text` in RotationalCipher.hs, i.e.:
-￼
-￼```haskell
+You need to implement the `rotate` function, which takes an `Int` and a `String`, and then encodes it using an rotational cipher.
+You can use the provided signature if you are unsure about the types, but don't let it restrict your creativity.
+
+This exercise works with textual data. For historical reasons, Haskell's
+`String` type is synonymous with `[Char]`, a list of characters. For more
+efficient handling of textual data, the `Text` type can be used.
+
+As an optional extension to this exercise, you can
+
+- read about [string types](https://haskell-lang.org/tutorial/string-types) in
+  Haskell.
+- add `- text` to your list of dependencies in package.yaml.
+- import `Data.Text` in [the following
+  way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+
+```haskell
+import qualified Data.Text as T
+import           Data.Text (Text)
+```
+
+- use the `Text` type e.g. `rotate :: Int -> Text -> Text` and refer to
+  `Data.Text` combinators as e.g. `T.pack`.
+- look up the documentation for
+  [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+- replace all occurrences of `String` with `Text` in RotationalCipher.hs, i.e.:
+
+```haskell
 rotate :: Int -> Text -> Text
-￼```
-￼
-￼This part is entirely optional.
+```
+
+This part is entirely optional.
+
+
+
 
 ## Getting Started
 

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -30,6 +30,39 @@ Ciphertext is written out in the same formatting as the input including spaces a
 - ROT13 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
 - ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
 
+## Hints
+￼
+￼You need to implement the `rotate` function, which takes an `Int` and a `String`, and then encodes it using an rotational cipher.
+￼You can use the provided signature ￼if you are unsure about the types, but don't let it restrict your creativity.
+￼
+￼This exercise works with textual data. For historical reasons, Haskell's
+￼`String` type is synonymous with `[Char]`, a list of characters. For more
+￼efficient handling of textual data, the `Text` type can be used.
+￼
+￼As an optional extension to this exercise, you can
+￼
+￼- read about [string types](https://haskell-lang.org/tutorial/string-types) in
+￼  Haskell.
+￼- add `- text` to your list of dependencies in package.yaml.
+￼- import `Data.Text` in [the following
+￼  way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+￼
+￼```haskell
+￼import qualified Data.Text as T
+￼import           Data.Text (Text)
+￼```
+
+￼- use the `Text` type e.g. `rotate :: Int -> Text -> Text` and refer to
+￼  `Data.Text` combinators as e.g. `T.pack`.
+￼- look up the documentation for
+￼  [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+￼- replace all occurrences of `String` with `Text` in RotationalCipher.hs, i.e.:
+￼
+￼```haskell
+rotate :: Int -> Text -> Text
+￼```
+￼
+￼This part is entirely optional.
 
 ## Getting Started
 

--- a/exercises/rotational-cipher/examples/success-text/package.yaml
+++ b/exercises/rotational-cipher/examples/success-text/package.yaml
@@ -1,0 +1,18 @@
+name: rotational-cipher
+
+dependencies:
+  - base
+
+library:
+  exposed-modules: RotationalCipher
+  source-dirs: src
+  dependencies:
+    - text
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - rotational-cipher
+      - hspec

--- a/exercises/rotational-cipher/examples/success-text/src/RotationalCipher.hs
+++ b/exercises/rotational-cipher/examples/success-text/src/RotationalCipher.hs
@@ -2,11 +2,17 @@ module RotationalCipher (rotate) where
 
 import qualified Data.Text as T
 import           Data.Text (Text)
-import           Data.List (elemIndex)
+import           Data.Char (isAsciiUpper, isAsciiLower, chr, ord)
 
 rotate :: Int -> Text -> Text
-rotate n = T.map (rotate' n ['a'..'z'] . rotate' n ['A'..'Z'])
-  where rotate' amountToRotate letters char =
-          case elemIndex char letters of
-            Nothing -> char
-            Just x  -> letters !! mod (x + amountToRotate) 26
+rotate = T.map . rotateLetter
+
+rotateLetter :: Int -> Char -> Char
+rotateLetter amountToRotate char
+  | isAsciiLower char = rotatedLetterStartingWith 'a'
+  | isAsciiUpper char = rotatedLetterStartingWith 'A'
+  | otherwise = char
+  where
+    rotatedLetterStartingWith :: Char -> Char
+    rotatedLetterStartingWith baseCharacter =
+      chr $ (ord char - ord baseCharacter + amountToRotate) `mod` 26 + ord baseCharacter

--- a/exercises/rotational-cipher/examples/success-text/src/RotationalCipher.hs
+++ b/exercises/rotational-cipher/examples/success-text/src/RotationalCipher.hs
@@ -1,0 +1,12 @@
+module RotationalCipher (rotate) where
+
+import qualified Data.Text as T
+import           Data.Text (Text)
+import           Data.List (elemIndex)
+
+rotate :: Int -> Text -> Text
+rotate n = T.map (rotate' n ['a'..'z'] . rotate' n ['A'..'Z'])
+  where rotate' amountToRotate letters char =
+          case elemIndex char letters of
+            Nothing -> char
+            Just x  -> letters !! mod (x + amountToRotate) 26

--- a/exercises/rotational-cipher/package.yaml
+++ b/exercises/rotational-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: rotational-cipher
-version: 1.2.0.3
+version: 1.2.0.4
 
 dependencies:
   - base

--- a/exercises/rotational-cipher/test/Tests.hs
+++ b/exercises/rotational-cipher/test/Tests.hs
@@ -16,7 +16,7 @@ specs = describe "rotate" $ for_ cases test
 
     test Case{..} = it description assertion
       where
-        assertion = rotate number (fromString phrase) `shouldBe` (fromString expected)
+        assertion = rotate number (fromString phrase) `shouldBe` fromString expected
 
 data Case = Case { description :: String
                  , number      :: Int

--- a/exercises/rotational-cipher/test/Tests.hs
+++ b/exercises/rotational-cipher/test/Tests.hs
@@ -3,6 +3,7 @@
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Data.String       (fromString)
 
 import RotationalCipher (rotate)
 
@@ -15,7 +16,7 @@ specs = describe "rotate" $ for_ cases test
 
     test Case{..} = it description assertion
       where
-        assertion = rotate number phrase `shouldBe` expected
+        assertion = rotate number (fromString phrase) `shouldBe` (fromString expected)
 
 data Case = Case { description :: String
                  , number      :: Int


### PR DESCRIPTION
Add `Data.Text` support for `rotational-cipher` exercise from https://github.com/exercism/haskell/issues/841.

This will allow students to use `Data.Text` to solve the `rotational-cipher` exercise.