### PR TITLE
Allow for use of Data.Text on atbash-cipher exercise

### DIFF
--- a/exercises/atbash-cipher/.meta/hints.md
+++ b/exercises/atbash-cipher/.meta/hints.md
@@ -1,0 +1,37 @@
+## Hints
+￼
+￼You need to implement the `decode` and `encode` functions, which decode and encode a `String` using an Atbash cipher.
+￼You can use the provided signature ￼if you are unsure about the types, but don't let it restrict your creativity.
+￼
+￼This exercise works with textual data. For historical reasons, Haskell's
+￼`String` type is synonymous with `[Char]`, a list of characters. For more
+￼efficient handling of textual data, the `Text` type can be used.
+￼
+￼As an optional extension to this exercise, you can
+￼
+￼- read about [string types](https://haskell-lang.org/tutorial/string-types) in
+￼  Haskell.
+￼- add `- text` to your list of dependencies in package.yaml.
+￼- import `Data.Text` in [the following
+￼  way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+￼
+￼```haskell
+￼import qualified Data.Text as T
+￼import           Data.Text (Text)
+￼```
+
+￼- use the `Text` type e.g. `decode :: Text -> Text` and refer to
+￼  `Data.Text` combinators as e.g. `T.pack`.
+￼- look up the documentation for
+￼  [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+￼- replace all occurrences of `String` with `Text` in Atbash.hs, i.e.:
+￼
+￼```haskell
+decode :: Text -> Text
+
+-- ...
+
+encode :: Text -> Text
+￼```
+￼
+￼This part is entirely optional.

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -28,6 +28,43 @@ things based on word boundaries.
 - Decoding `gvhg` gives `test`
 - Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
 
+## Hints
+￼
+￼You need to implement the `decode` and `encode` functions, which decode and encode a `String` using an Atbash cipher.
+￼You can use the provided signature ￼if you are unsure about the types, but don't let it restrict your creativity.
+￼
+￼This exercise works with textual data. For historical reasons, Haskell's
+￼`String` type is synonymous with `[Char]`, a list of characters. For more
+￼efficient handling of textual data, the `Text` type can be used.
+￼
+￼As an optional extension to this exercise, you can
+￼
+￼- read about [string types](https://haskell-lang.org/tutorial/string-types) in
+￼  Haskell.
+￼- add `- text` to your list of dependencies in package.yaml.
+￼- import `Data.Text` in [the following
+￼  way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
+￼
+￼```haskell
+￼import qualified Data.Text as T
+￼import           Data.Text (Text)
+￼```
+
+￼- use the `Text` type e.g. `decode :: Text -> Text` and refer to
+￼  `Data.Text` combinators as e.g. `T.pack`.
+￼- look up the documentation for
+￼  [`Data.Text`](https://hackage.haskell.org/package/text/docs/Data-Text.html).
+￼- replace all occurrences of `String` with `Text` in Atbash.hs, i.e.:
+￼
+￼```haskell
+decode :: Text -> Text
+
+-- ...
+
+encode :: Text -> Text
+￼```
+￼
+￼This part is entirely optional.
 
 ## Getting Started
 

--- a/exercises/atbash-cipher/examples/success-text/package.yaml
+++ b/exercises/atbash-cipher/examples/success-text/package.yaml
@@ -1,0 +1,18 @@
+name: atbash-cipher
+
+dependencies:
+  - base
+
+library:
+  exposed-modules: Atbash
+  source-dirs: src
+  dependencies:
+    - text
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - atbash-cipher
+      - hspec

--- a/exercises/atbash-cipher/examples/success-text/src/Atbash.hs
+++ b/exercises/atbash-cipher/examples/success-text/src/Atbash.hs
@@ -1,0 +1,21 @@
+module Atbash (decode, encode) where
+
+import           Data.Char (isLetter, toLower, isAlphaNum)
+import qualified Data.Text as T
+import           Data.Text (Text)
+
+decode :: Text -> Text
+decode = T.map atbashChar . T.filter isAlphaNum
+
+encode :: Text -> Text
+encode = T.unwords . T.chunksOf 5 . decode
+
+atbashChar :: Char -> Char
+atbashChar c
+    | isLetter c = symmetric
+    | otherwise  = c
+  where
+    lc = toLower c
+    symmetric = toEnum $ fromEnum 'a'
+                       + fromEnum 'z'
+                       - fromEnum lc

--- a/exercises/atbash-cipher/package.yaml
+++ b/exercises/atbash-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: atbash-cipher
-version: 1.2.0.6
+version: 1.2.0.7
 
 dependencies:
   - base

--- a/exercises/atbash-cipher/test/Tests.hs
+++ b/exercises/atbash-cipher/test/Tests.hs
@@ -3,6 +3,7 @@
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Data.String       (fromString)
 
 import Atbash (encode, decode)
 
@@ -14,7 +15,7 @@ specs = do
           describe "encode" $ for_ encodeCases $ test encode
           describe "decode" $ for_ decodeCases $ test decode
   where
-    test f Case{..} = it description $ f phrase `shouldBe` expected
+    test f Case{..} = it description $ f (fromString phrase) `shouldBe` (fromString expected)
 
 data Case = Case { description :: String
                  , phrase      :: String


### PR DESCRIPTION
Add `Data.Text` support for `atbash-cipher` exercise from https://github.com/exercism/haskell/issues/841.

This will allow students to use `Data.Text` to solve the `atbash-cipher` exercise.