### PR TITLE
Add QuickCheck test for reshaping in "matrix" exercise

### DIFF
--- a/exercises/matrix/examples/success-standard/package.yaml
+++ b/exercises/matrix/examples/success-standard/package.yaml
@@ -15,3 +15,4 @@ tests:
     dependencies:
       - matrix
       - hspec
+      - QuickCheck

--- a/exercises/matrix/package.yaml
+++ b/exercises/matrix/package.yaml
@@ -1,5 +1,5 @@
 name: matrix
-version: 1.3.0.8
+version: 1.3.0.9
 
 dependencies:
   - base

--- a/exercises/matrix/package.yaml
+++ b/exercises/matrix/package.yaml
@@ -20,3 +20,4 @@ tests:
     dependencies:
       - matrix
       - hspec
+      - QuickCheck

--- a/exercises/matrix/test/Tests.hs
+++ b/exercises/matrix/test/Tests.hs
@@ -26,31 +26,31 @@ specs :: Spec
 specs = do
 
     let intMatrix = fromString :: String -> Matrix Int
-    let vector = Vector.fromList
+    let shouldBeVector x v = x `shouldBe` Vector.fromList v
 
     it "extract row from one number matrix" $
-      row 1 (intMatrix "1") `shouldBe` vector [1]
+      row 1 (intMatrix "1") `shouldBeVector` [1]
 
     it "can extract row" $
-      row 2 (intMatrix "1 2\n3 4") `shouldBe` vector [3, 4]
+      row 2 (intMatrix "1 2\n3 4") `shouldBeVector` [3, 4]
 
     it "extract row where numbers have different widths" $
-      row 2 (intMatrix "1 2\n10 20") `shouldBe` vector [10, 20]
+      row 2 (intMatrix "1 2\n10 20") `shouldBeVector` [10, 20]
 
     it "can extract row from non-square matrix with no corresponding column" $
-      row 4 (intMatrix "1 2 3\n4 5 6\n7 8 9\n8 7 6") `shouldBe` vector [8, 7, 6]
+      row 4 (intMatrix "1 2 3\n4 5 6\n7 8 9\n8 7 6") `shouldBeVector` [8, 7, 6]
 
     it "extract column from one number matrix" $
-      column 1 (intMatrix "1") `shouldBe` vector [1]
+      column 1 (intMatrix "1") `shouldBeVector` [1]
 
     it "can extract column" $
-      column 3 (intMatrix "1 2 3\n4 5 6\n7 8 9") `shouldBe` vector [3, 6, 9]
+      column 3 (intMatrix "1 2 3\n4 5 6\n7 8 9") `shouldBeVector` [3, 6, 9]
 
     it "can extract column from non-square matrix with no corresponding row" $
-      column 4 (intMatrix "1 2 3 4\n5 6 7 8\n9 8 7 6") `shouldBe` vector [4, 8, 6]
+      column 4 (intMatrix "1 2 3 4\n5 6 7 8\n9 8 7 6") `shouldBeVector` [4, 8, 6]
 
     it "extract column where numbers have different widths" $
-      column 2 (intMatrix "89 1903 3\n18 3 1\n9 4 800") `shouldBe` vector [1903, 3, 4]
+      column 2 (intMatrix "89 1903 3\n18 3 1\n9 4 800") `shouldBeVector` [1903, 3, 4]
 
     -- Track-specific tests:
 
@@ -91,7 +91,7 @@ specs = do
       in forAllShow (genNonEmptyMatrix >>= genNewShape) failMsg shapeMatches
 
     it "flatten" $
-      flatten (intMatrix "1 2\n3 4") `shouldBe` vector [1, 2, 3, 4]
+      flatten (intMatrix "1 2\n3 4") `shouldBeVector` [1, 2, 3, 4]
 
 genNewShape :: Matrix Int -> Gen (Matrix Int, (Int, Int))
 genNewShape m = (\c -> (m, (size `quot` c, c))) <$> elements factors


### PR DESCRIPTION
Per #881, adds a QuickCheck test for the property that `shape . reshape dimension $ matrix == dimension` for all valid `dimension`/`matrix`.

Closes #881.