### PR TITLE
config.json: add "online_editor" section

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,10 @@
   "blurb": "Haskell is a functional programming language which is pure and statically-typed. It's known for lazy evaluation, where evaluation is deferred until necessary, and its purity, where monads are used for working with side-effects.",
   "ignore_pattern": "example",
   "solution_pattern": "example.*[.]hs",
+  "online_editor": {
+    "indent_style": "space",
+    "indent_size": 2
+  },
   "exercises": [
     {
       "slug": "hello-world",


### PR DESCRIPTION
As part of "Research Experiment 1" (#884), and in correspondence with a similar pull request exercism/ruby#1016, this adds track configuration for the upcoming online editor.

Since this configuration does not allow context-sensitive indentation, any choice of "2 spaces" or "4 spaces" seems like an arbitrary default.