### PR TITLE
resistor-color: Mark exercise as foregone

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,9 @@
   "blurb": "Haskell is a functional programming language which is pure and statically-typed. It's known for lazy evaluation, where evaluation is deferred until necessary, and its purity, where monads are used for working with side-effects.",
   "ignore_pattern": "example",
   "solution_pattern": "example.*[.]hs",
+  "foregone": [
+    "resistor-color"
+  ],
   "exercises": [
     {
       "slug": "hello-world",


### PR DESCRIPTION
resistor-color-duo was added in #808.

resistor-color-trio was added in #869.

Yet there is no resistor-color. I argue that there shouldn't be.

A reasonable solution might look like

```haskell
data Color = ...
  deriving (Eq, Enum, Bounded)

colorCode :: Color -> Int
colorCode = fromEnum

colors :: [Color]
colors = [minBound..]
```

which makes it approximately as simple as the gigasecond exercise which was marked as deprecated in #280 (decision made in #230). Still, if it is simply missing, it will appear as an exercise that is potentially implementable on https://tracks.exercism.io/haskell/master/unimplemented

Since a question was raised about this exercise once, marking it as foregone will limit further requests made in vain.