### PR TITLE
Forth: Rename 'empty' to 'emptyState'

### DIFF
--- a/exercises/forth/.meta/hints.md
+++ b/exercises/forth/.meta/hints.md
@@ -3,7 +3,7 @@
 To complete this exercise, you need to create the data type `ForthState`
 and implement the following functions:
 
-- `empty` returns an empty `ForthState`.
+- `emptyState` returns an empty `ForthState`.
 - `evalText` evaluates an input Text, returning the new state.
 - `toList` returns the current stack as a list, with the element on top
 of the stack being the rightmost (last) element.

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -30,7 +30,7 @@ Words are case-insensitive.
 To complete this exercise, you need to create the data type `ForthState`
 and implement the following functions:
 
-- `empty` returns an empty `ForthState`.
+- `emptyState` returns an empty `ForthState`.
 - `evalText` evaluates an input Text, returning the new state.
 - `toList` returns the current stack as a list, with the element on top
 of the stack being the rightmost (last) element.

--- a/exercises/forth/examples/success-standard/src/Forth.hs
+++ b/exercises/forth/examples/success-standard/src/Forth.hs
@@ -4,7 +4,7 @@ module Forth
   , ForthState
   , evalText
   , toList
-  , empty
+  , emptyState
   ) where
 
 import Data.Map (Map)
@@ -62,8 +62,8 @@ defaultWords = M.fromList . map (first T.toCaseFold) $
   , ("over", Over)
   ]
 
-empty :: ForthState
-empty = ForthState
+emptyState :: ForthState
+emptyState = ForthState
       { forthStack = []
       , forthCode  = []
       , forthWords = defaultWords

--- a/exercises/forth/package.yaml
+++ b/exercises/forth/package.yaml
@@ -1,5 +1,5 @@
 name: forth
-version: 1.7.1.12
+version: 1.7.1.13
 
 dependencies:
   - base

--- a/exercises/forth/src/Forth.hs
+++ b/exercises/forth/src/Forth.hs
@@ -5,7 +5,7 @@ module Forth
   , ForthState
   , evalText
   , toList
-  , empty
+  , emptyState
   ) where
 
 import Data.Text (Text)
@@ -19,8 +19,8 @@ data ForthError
 
 data ForthState = Dummy
 
-empty :: ForthState
-empty = error "You need to implement this function."
+emptyState :: ForthState
+emptyState = error "You need to implement this function."
 
 evalText :: Text -> ForthState -> Either ForthError ForthState
 evalText text stack = error "You need to implement this function."

--- a/exercises/forth/test/Tests.hs
+++ b/exercises/forth/test/Tests.hs
@@ -4,7 +4,7 @@ import Control.Monad     (foldM)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-import Forth (ForthError(..), empty, evalText, toList)
+import Forth (ForthError(..), emptyState, evalText, toList)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
@@ -12,7 +12,7 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = do
 
-    let runTexts = fmap toList . foldM (flip evalText) empty
+    let runTexts = fmap toList . foldM (flip evalText) emptyState
 
     describe "parsing and numbers" $
       it "numbers just get pushed onto the stack" $


### PR DESCRIPTION
To avoid colliding with `Control.Applicative.empty` when, for example, using applicative parsing that re-exports this library, the `empty` value is suggested renamed to `emptyState` which is unambiguous.

Bump version from 1.7.1.12 to 1.7.1.13.

This addresses all instances of the word "empty" in the exercise repository:

```
$ ack empty
examples/success-standard/src/Forth.hs
7:  , emptyState
65:emptyState :: ForthState
66:emptyState = ForthState

test/Tests.hs
7:import Forth (ForthError(..), emptyState, evalText, toList)
15:    let runTexts = fmap toList . foldM (flip evalText) emptyState

README.md
33:- `emptyState` returns an empty `ForthState`.

src/Forth.hs
8:  , emptyState
22:emptyState :: ForthState
23:emptyState = error "You need to implement this function."

.meta/hints.md
6:- `emptyState` returns an empty `ForthState`.
```