### PR TITLE
Clock: Add `deriving Eq` to stub to make it testable

### DIFF
--- a/exercises/clock/.meta/DONT-TEST-STUB
+++ b/exercises/clock/.meta/DONT-TEST-STUB
@@ -1,1 +1,0 @@
-We ask for the Clock to be an instance of Num; let students figure this out.

--- a/exercises/clock/package.yaml
+++ b/exercises/clock/package.yaml
@@ -1,5 +1,5 @@
 name: exercism-clock
-version: 2.4.0.9
+version: 2.4.0.10
 
 dependencies:
   - base

--- a/exercises/clock/src/Clock.hs
+++ b/exercises/clock/src/Clock.hs
@@ -1,6 +1,7 @@
 module Clock (addDelta, fromHourMin, toString) where
 
 data Clock = Dummy
+  deriving Eq
 
 fromHourMin :: Int -> Int -> Clock
 fromHourMin hour min = error "You need to implement this function."


### PR DESCRIPTION
Clock is the last remaining exercise that has the .meta/DONT-TEST-STUB file because the type in the src/Clock.hs stub is not compatible with the test suite.

Other examples of exercises that were revised so that testing the stub became possible are listed in #466. The difference is that those all had `data` definitions, whereas Clock is ideally solved with a 'newtype' and an appropriate alias.

The DONT-TEST-STUB mechanism was added by @petertseng in #464 and in particular the commits

 - 1d91ceb1af24be5c0f2f051e82e429d171515343 (Travis code)
 - 342b932a79824a547c443dee741aa2f966f66b58 (Clock-specific)

The change made in this commit argues that since the example solution has `deriving Eq`, adding this to the stub *will* make the exercise a bit easier, but it still won't give away the central piece.

The motivation behind removing DONT-TEST-STUB in Clock is that with this single effort, we can say that all stubs can be compiled and tested. To motivate further, I will cite @rbasso in #466:

> I think that this is the way to go. We have to sacrifice a little
> flexibility in designing exercises, but we gain a more coherent
> user-experience and automatic testing of stubs. :+1:

This bumps the exercise's version from 2.4.0.9 to 2.4.0.10.