### PR TITLE
bank-account: Fixed tests

### DIFF
--- a/exercises/bank-account/examples/success-standard/src/BankAccount.hs
+++ b/exercises/bank-account/examples/success-standard/src/BankAccount.hs
@@ -3,7 +3,7 @@ module BankAccount ( BankAccount
                    , getBalance, incrementBalance) where
 import Control.Concurrent.STM (TVar, atomically, newTVar, readTVar, readTVarIO, writeTVar)
 
-newtype BankAccount = BankAccount { unBankAccount :: TVar (Maybe Int) }
+newtype BankAccount = BankAccount { unBankAccount :: TVar (Maybe Integer) }
 
 openAccount :: IO BankAccount
 openAccount = atomically $ BankAccount <$> newTVar (Just 0)
@@ -11,10 +11,10 @@ openAccount = atomically $ BankAccount <$> newTVar (Just 0)
 closeAccount :: BankAccount -> IO ()
 closeAccount = atomically . flip writeTVar Nothing . unBankAccount
 
-getBalance :: BankAccount -> IO (Maybe Int)
+getBalance :: BankAccount -> IO (Maybe Integer)
 getBalance = readTVarIO . unBankAccount
 
-incrementBalance :: BankAccount -> Int -> IO (Maybe Int)
+incrementBalance :: BankAccount -> Integer -> IO (Maybe Integer)
 incrementBalance acct delta = atomically $ do
   let b = unBankAccount acct
   bal <- fmap (delta +) <$> readTVar b

--- a/exercises/bank-account/package.yaml
+++ b/exercises/bank-account/package.yaml
@@ -1,5 +1,5 @@
 name: bank-account
-version: 0.1.0.3
+version: 0.1.0.4
 
 dependencies:
   - base

--- a/exercises/bank-account/package.yaml
+++ b/exercises/bank-account/package.yaml
@@ -16,6 +16,7 @@ tests:
   test:
     main: Tests.hs
     source-dirs: test
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N
     dependencies:
       - bank-account
       - hspec


### PR DESCRIPTION
There were two major issues with those tests. First and foremost: they
were compiled without `-threaded`, meaning there was no actual
concurrency during the test runs, making the test that spawns twenty
threads meaningless.

Secondly, there's a behaviour that wasn't tested: if an account
exists, we expect increment and balance to never return
`Nothing`. That should only ever happen if the account is closed. This
commit therefore also adds a test that mixes increments and balance
checks to ensure all of them return `Just`.

This commit also increases the number of parallel threads to 50 (which
was the amount after which I could reliably make the tests fail on my
machine).

I have tried an alternative solution: use Control.Concurrent.QSemN to
release all threads "at the same time"; but since taking resources
from the semaphore is an atomic operation this wasn't working (each
thread was grabbing a resource one by one).