### PR TITLE
dominoes: added double-orientation test

### DIFF
--- a/exercises/dominoes/package.yaml
+++ b/exercises/dominoes/package.yaml
@@ -1,5 +1,5 @@
 name: dominoes
-version: 2.1.0.7
+version: 2.1.0.8
 
 dependencies:
   - base

--- a/exercises/dominoes/test/Tests.hs
+++ b/exercises/dominoes/test/Tests.hs
@@ -74,6 +74,10 @@ cases = [ Case { description = "empty input = empty output"
                , input       = [(1, 2), (1, 3), (2, 3)]
                , expected    = True
                }
+        , Case { description = "cannot use the same domino in both directions"
+               , input       = [(1, 2), (2, 3), (2, 1)]
+               , expected    = False
+               }
         , Case { description = "can't be chained"
                , input       = [(1, 2), (4, 1), (2, 3)]
                , expected    = False


### PR DESCRIPTION
I found a case where a student's code would mistakenly use the same
domino in both ways. With their code, the chain
`[(1, 2), (2, 3), (2,1)]` would be considered valid, as they would
first match (1,2) with (2,3), then swap the domino and match (3,2)
with (2,1).

Surprisingly, none of the tests currently catch this, hence this
patch.