### PR TITLE
dominoes: add long test with no solution

### DIFF
--- a/exercises/dominoes/package.yaml
+++ b/exercises/dominoes/package.yaml
@@ -1,5 +1,5 @@
 name: dominoes
-version: 2.1.0.8
+version: 2.1.0.9
 
 dependencies:
   - base

--- a/exercises/dominoes/test/Tests.hs
+++ b/exercises/dominoes/test/Tests.hs
@@ -106,4 +106,8 @@ cases = [ Case { description = "empty input = empty output"
                , input       = [(1, 2), (5, 3), (3, 1), (1, 2), (2, 4), (1, 6), (2, 3), (3, 4), (5, 6)]
                , expected    = True
                }
+        , Case { description = "twelve elements - no loop"
+               , input       = [(1, 2), (5, 3), (3, 1), (1, 2), (2, 4), (1, 6), (2, 3), (3, 4), (5, 6), (3,6), (4,5), (2,1)]
+               , expected    = False
+               }
         ]


### PR DESCRIPTION
This is meant to discourage students from using a solution that simply
tries permutations of the domino chain.