### PR TITLE
Fix fetch-configlet.

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -26,7 +26,7 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
+VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/location:/{print $NF}' | tr -d '\r')"
 URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
 curl -s --location $URL | tar xz -C bin/

--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -26,7 +26,9 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
+VERSION="$(curl --head --silent $LATEST | perl -nE 's/\R//g; /^location:/i && print [split/\//]->[-1]')"
+URL="https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz"
+echo "VERSION = $VERSION"
+echo "URL = $URL"
 
 curl -s --location $URL | tar xz -C bin/


### PR DESCRIPTION
Travis builds are failing because of fetch-configlet failures, as tracked in https://github.com/exercism/configlet/issues/173. This patch is a copy of https://github.com/exercism/cpp/pull/344, which fixed the cpp track.