### PR TITLE
Leap: Remove hint to use guards

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,7 +27,7 @@
       "difficulty": 1,
       "topics": [
         "booleans",
-        "guards"
+        "expressions"
       ]
     },
     {

--- a/exercises/bob/.meta/hints.md
+++ b/exercises/bob/.meta/hints.md
@@ -8,6 +8,12 @@ about the types, but don't let it restrict your creativity:
 responseFor :: String -> String
 ```
 
+To solve this exercise you may read up on:
+
+- [Guards][guards]
+
+[guards]: https://www.futurelearn.com/courses/functional-programming-haskell/0/steps/27226
+
 This exercise works with textual data. For historical reasons, Haskell's
 `String` type is synonymous with `[Char]`, a list of characters. For more
 efficient handling of textual data, the `Text` type can be used.

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -25,6 +25,12 @@ about the types, but don't let it restrict your creativity:
 responseFor :: String -> String
 ```
 
+To solve this exercise you may read up on:
+
+- [Guards][guards]
+
+[guards]: https://www.futurelearn.com/courses/functional-programming-haskell/0/steps/27226
+
 This exercise works with textual data. For historical reasons, Haskell's
 `String` type is synonymous with `[Char]`, a list of characters. For more
 efficient handling of textual data, the `Text` type can be used.

--- a/exercises/leap/.meta/hints.md
+++ b/exercises/leap/.meta/hints.md
@@ -1,9 +1,4 @@
 ## Hints
 
 To complete this exercise you need to implement the function `isLeapYear`
-that takes a year and determines whether it is a leap year. To solve this
-exercise you may read up on:
-
-- [Guards][guards]
-
-[guards]: https://www.futurelearn.com/courses/functional-programming-haskell/0/steps/27226
+that takes a year and determines whether it is a leap year.

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -26,12 +26,7 @@ phenomenon, go watch [this youtube video][video].
 ## Hints
 
 To complete this exercise you need to implement the function `isLeapYear`
-that takes a year and determines whether it is a leap year. To solve this
-exercise you may read up on:
-
-- [Guards][guards]
-
-[guards]: https://www.futurelearn.com/courses/functional-programming-haskell/0/steps/27226
+that takes a year and determines whether it is a leap year.
 
 
 


### PR DESCRIPTION
I' like to suggest to remove the hint to use guards from the Leap exercise and move it to the Bob exercise (where guards are one of learning goals anyway).

Rationale: Most students have prior knowledge of some imperative language, which emphasizes statements. Haskell as a functional language emphasizes expression, which is not intuitive at first glance. Many students use nested if-then-else and also guards don't encourage students to start thinking differently. Therefore, one of the first exercises shall put focus on pure expressions. When using guards it is unavoidable to have Boolean literals on the right-hand side, which is not a good style and is therefore sub-optimal for one of the first exercises.