### PR TITLE
Luhn: Update tests to 1.7.0 (1 changed tests, 2 new tests)

### DIFF
--- a/exercises/luhn/package.yaml
+++ b/exercises/luhn/package.yaml
@@ -1,5 +1,5 @@
 name: luhn
-version: 1.3.0.6
+version: 1.7.0.7
 
 dependencies:
   - base

--- a/exercises/luhn/test/Tests.hs
+++ b/exercises/luhn/test/Tests.hs
@@ -48,14 +48,22 @@ cases = [ Case { description = "single digit strings can not be valid"
                , input       = "8273 1232 7352 0569"
                , expected    = False
                }
+        , Case { description = "invalid long number with an even remainder"
+               , input       = "1 2345 6789 1234 5678 9012"
+               , expected    = False
+               }
         , Case { description = "valid number with an even number of digits"
                , input       = "095 245 88"
                , expected    = True
                }
+        , Case { description = "valid number with an odd number of spaces"
+               , input       = "234 567 891 234"
+               , expected    = True
+               }
 -- This track is not testing these cases, since we would rather focus on the algorithm,
 -- and because it seems strange to be unable to distinguish between well-formed invalid input and malformed input.
---        , Case { description = "valid strings with a non-digit included become invalid"
---               , input       = "055a 444 285"
+--        , Case { description = "valid strings with a non-digit added at the end become invalid"
+--               , input       = "059a"
 --               , expected    = False
 --               }
 --        , Case { description = "valid strings with punctuation included become invalid"
@@ -78,7 +86,11 @@ cases = [ Case { description = "single digit strings can not be valid"
                , input       = "091"
                , expected    = True
                }
---        , Case { description = "strings with non-digits is invalid"
+--        , Case { description = "using ascii value for non-doubled non-digit isn't allowed"
+--               , input       = "055b 444 285"
+--               , expected    = False
+--               }
+--        , Case { description = "using ascii value for doubled non-digit isn't allowed"
 --               , input       = ":9"
 --               , expected    = False
 --               }


### PR DESCRIPTION
Changes included:

1. exercism/problem-specifications#1480: 1.4.0 to 1.5.0:
   Change "055a 444 285" test into "055b 444 285" for subtle reasons.
   New test name: using ascii value for doubled non-digit isn't allowed

2. exercism/problem-specifications#1500: 1.5.0 to 1.6.0:
   Add test case: valid number with an odd number of spaces

3. exercism/problem-specifications#1635: 1.6.0 to 1.7.0:
   Add test case: invalid long number with an even remainder

*(Edit by @sshine: Added short description of the addressed commits.)*