### PR TITLE
nucleotide-count: use findWithDefault to accept sparse maps

### DIFF
--- a/exercises/nucleotide-count/package.yaml
+++ b/exercises/nucleotide-count/package.yaml
@@ -1,5 +1,5 @@
 name: nucleotide-count
-version: 1.3.0.7
+version: 1.3.0.8
 
 dependencies:
   - base

--- a/exercises/nucleotide-count/test/Tests.hs
+++ b/exercises/nucleotide-count/test/Tests.hs
@@ -1,8 +1,9 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# language LambdaCase #-}
 
 import Data.Either       (isLeft)
-import Data.Map          (fromList)
-import Test.Hspec        (Spec, describe, it, shouldBe, shouldSatisfy)
+import Data.Map          (findWithDefault)
+import Test.Hspec        (Spec, describe, it, shouldSatisfy)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
 import DNA (nucleotideCounts, Nucleotide(..))
@@ -13,7 +14,9 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = do
 
-          let x `matchesMap` y = x `shouldBe` (Right . fromList) y
+          let x `matchesMap` y = shouldSatisfy x $ \case
+                Right count -> and [ findWithDefault 0 n count == c | (n,c) <- y ]
+                Left _ -> False
 
           describe "nucleotideCounts" $ do
 


### PR DESCRIPTION
Bump version from 1.3.0.7 to 1.3.0.8.

This was created by @jitwit in #903 and accidentally closed by a force-push by me.

This closes #902.