### PR TITLE
clock: Improve hint

### DIFF
--- a/exercises/clock/.meta/hints.md
+++ b/exercises/clock/.meta/hints.md
@@ -22,7 +22,7 @@ You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,
 newtype or type synonym.
 
-If you need help getting started with Types, take a look at:
+If you need help getting started with types, take a look at:
 - [Data Types in 5 Steps][types]
 
 [types]: https://mmhaskell.com/blog/2017/12/24/haskell-data-types-in-5-steps

--- a/exercises/clock/.meta/hints.md
+++ b/exercises/clock/.meta/hints.md
@@ -1,3 +1,9 @@
+Implement a 24 hour clock that handles times.
+
+You should be able to add and subtract hours and minutes to it.
+
+Two clocks that represent the same time should be equal to each other.
+
 ## Hints
 
 To complete this exercise you need to define the data type `Clock`,
@@ -10,6 +16,19 @@ add an `Eq` instance, and implement the functions:
 `addDelta` adds a duration, expressed in hours and minutes, to a given time,
 represented by an instance of `Clock`.
 
+`fromHourMin` takes an hour and minute, and returns an instance of `Clock` with 
+those hours and minutes.
+
+`toString` takes an instance of `Clock` and returns a string representation 
+of the clock, in 0 padded format like "08:03" or "22:35"
+
 You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,
 newtype or type synonym.
+
+If you need help getting started with Types, take a look at:
+- [Data Types in 5 Steps][types]
+
+[types]: https://mmhaskell.com/blog/2017/12/24/haskell-data-types-in-5-steps
+
+

--- a/exercises/clock/.meta/hints.md
+++ b/exercises/clock/.meta/hints.md
@@ -1,6 +1,6 @@
-It's a 24 hour clock going from "00:00" to "23:59".
-
 ## Hints
+
+It's a 24 hour clock going from "00:00" to "23:59".
 
 To complete this exercise you need to define the data type `Clock`,
 add an `Eq` instance, and implement the functions:

--- a/exercises/clock/.meta/hints.md
+++ b/exercises/clock/.meta/hints.md
@@ -1,3 +1,5 @@
+It's a 24 hour clock going from "00:00" to "23:59".
+
 ## Hints
 
 To complete this exercise you need to define the data type `Clock`,
@@ -14,7 +16,7 @@ represented by an instance of `Clock`.
 those hours and minutes.
 
 `toString` takes an instance of `Clock` and returns a string representation 
-of the clock, in 0 padded format like "08:03" or "22:35"
+of the clock, in 0-padded format like "08:03" or "22:35"
 
 You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,

--- a/exercises/clock/.meta/hints.md
+++ b/exercises/clock/.meta/hints.md
@@ -1,9 +1,3 @@
-Implement a 24 hour clock that handles times.
-
-You should be able to add and subtract hours and minutes to it.
-
-Two clocks that represent the same time should be equal to each other.
-
 ## Hints
 
 To complete this exercise you need to define the data type `Clock`,
@@ -30,5 +24,3 @@ If you need help getting started with Types, take a look at:
 - [Data Types in 5 Steps][types]
 
 [types]: https://mmhaskell.com/blog/2017/12/24/haskell-data-types-in-5-steps
-
-

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -1,8 +1,8 @@
 # Clock
 
-Implement a clock that handles times without dates.
+Implement a 24 hour clock that handles times.
 
-You should be able to add and subtract minutes to it.
+You should be able to add and subtract hours and minutes to it.
 
 Two clocks that represent the same time should be equal to each other.
 
@@ -18,9 +18,20 @@ add an `Eq` instance, and implement the functions:
 `addDelta` adds a duration, expressed in hours and minutes, to a given time,
 represented by an instance of `Clock`.
 
+`fromHourMin` takes an hour and minute, and returns an instance of `Clock` with 
+those hours and minutes.
+
+`toString` takes an instance of `Clock` and returns a string representation 
+of the clock, in 0 padded format like "08:03" or "22:35"
+
 You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,
 newtype or type synonym.
+
+If you need help getting started with Types, take a look at:
+- [Data Types in 5 Steps][types]
+
+[types]: https://mmhaskell.com/blog/2017/12/24/haskell-data-types-in-5-steps
 
 
 

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -1,10 +1,12 @@
 # Clock
 
-Implement a 24 hour clock that handles times.
+Implement a clock that handles times without dates.
 
-You should be able to add and subtract hours and minutes to it.
+You should be able to add and subtract minutes to it.
 
 Two clocks that represent the same time should be equal to each other.
+
+It's a 24 hour clock going from "00:00" to "23:59".
 
 ## Hints
 
@@ -22,7 +24,7 @@ represented by an instance of `Clock`.
 those hours and minutes.
 
 `toString` takes an instance of `Clock` and returns a string representation 
-of the clock, in 0 padded format like "08:03" or "22:35"
+of the clock, in 0-padded format like "08:03" or "22:35"
 
 You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -6,9 +6,9 @@ You should be able to add and subtract minutes to it.
 
 Two clocks that represent the same time should be equal to each other.
 
-It's a 24 hour clock going from "00:00" to "23:59".
-
 ## Hints
+
+It's a 24 hour clock going from "00:00" to "23:59".
 
 To complete this exercise you need to define the data type `Clock`,
 add an `Eq` instance, and implement the functions:
@@ -30,7 +30,7 @@ You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,
 newtype or type synonym.
 
-If you need help getting started with Types, take a look at:
+If you need help getting started with types, take a look at:
 - [Data Types in 5 Steps][types]
 
 [types]: https://mmhaskell.com/blog/2017/12/24/haskell-data-types-in-5-steps


### PR DESCRIPTION
Closes #908 
I added a few things:
- Updated implementation lines to specifiy the type of clock, and that you can add or subtract both hours and minutes from it.
- Added descriptions for the remaining 2 functions: toString and fromHourMin
- Added a resource from learn you a haskell for creating and using custom types
- Added restrictions to not use the inbuilt data.dates package. I followed the format of other problems.