### PR TITLE
stack.yaml: lts-15.8 -> lts-16.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
     - $HOME/.foldercache # Per exercise `.stack-work` cache.
 
 env:
- - RESOLVER="lts-15.8" CURRENT="YES"  # Equal to each stack.yaml.
- - RESOLVER="nightly"                 # Latest nightly snapshot.
+ - RESOLVER="lts-16.21" CURRENT="YES"  # Equal to each stack.yaml.
+ - RESOLVER="nightly"                  # Latest nightly snapshot.
 
 matrix:
   allow_failures:             # The snapshot `nightly` is just an alias to

--- a/exercises/accumulate/stack.yaml
+++ b/exercises/accumulate/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/acronym/stack.yaml
+++ b/exercises/acronym/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/all-your-base/stack.yaml
+++ b/exercises/all-your-base/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/allergies/stack.yaml
+++ b/exercises/allergies/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/alphametics/stack.yaml
+++ b/exercises/alphametics/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/anagram/stack.yaml
+++ b/exercises/anagram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/armstrong-numbers/stack.yaml
+++ b/exercises/armstrong-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/atbash-cipher/stack.yaml
+++ b/exercises/atbash-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/bank-account/stack.yaml
+++ b/exercises/bank-account/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/beer-song/stack.yaml
+++ b/exercises/beer-song/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/binary-search-tree/stack.yaml
+++ b/exercises/binary-search-tree/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/binary-search/stack.yaml
+++ b/exercises/binary-search/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/binary/stack.yaml
+++ b/exercises/binary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/bob/stack.yaml
+++ b/exercises/bob/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/bowling/stack.yaml
+++ b/exercises/bowling/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/change/stack.yaml
+++ b/exercises/change/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/clock/stack.yaml
+++ b/exercises/clock/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/collatz-conjecture/stack.yaml
+++ b/exercises/collatz-conjecture/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/complex-numbers/stack.yaml
+++ b/exercises/complex-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/connect/stack.yaml
+++ b/exercises/connect/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/crypto-square/stack.yaml
+++ b/exercises/crypto-square/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/custom-set/stack.yaml
+++ b/exercises/custom-set/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/diamond/stack.yaml
+++ b/exercises/diamond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/difference-of-squares/stack.yaml
+++ b/exercises/difference-of-squares/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/dnd-character/stack.yaml
+++ b/exercises/dnd-character/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/dominoes/stack.yaml
+++ b/exercises/dominoes/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/etl/stack.yaml
+++ b/exercises/etl/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/food-chain/stack.yaml
+++ b/exercises/food-chain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/forth/stack.yaml
+++ b/exercises/forth/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/gigasecond/stack.yaml
+++ b/exercises/gigasecond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/go-counting/stack.yaml
+++ b/exercises/go-counting/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/grade-school/stack.yaml
+++ b/exercises/grade-school/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/grains/stack.yaml
+++ b/exercises/grains/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/hamming/stack.yaml
+++ b/exercises/hamming/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/hello-world/stack.yaml
+++ b/exercises/hello-world/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/hexadecimal/stack.yaml
+++ b/exercises/hexadecimal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/house/stack.yaml
+++ b/exercises/house/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/isbn-verifier/stack.yaml
+++ b/exercises/isbn-verifier/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/isogram/stack.yaml
+++ b/exercises/isogram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/kindergarten-garden/stack.yaml
+++ b/exercises/kindergarten-garden/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/largest-series-product/stack.yaml
+++ b/exercises/largest-series-product/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/leap/stack.yaml
+++ b/exercises/leap/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/lens-person/stack.yaml
+++ b/exercises/lens-person/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/linked-list/stack.yaml
+++ b/exercises/linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/list-ops/stack.yaml
+++ b/exercises/list-ops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/luhn/stack.yaml
+++ b/exercises/luhn/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/matching-brackets/stack.yaml
+++ b/exercises/matching-brackets/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/matrix/stack.yaml
+++ b/exercises/matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/meetup/stack.yaml
+++ b/exercises/meetup/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/minesweeper/stack.yaml
+++ b/exercises/minesweeper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/nth-prime/stack.yaml
+++ b/exercises/nth-prime/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/nucleotide-count/stack.yaml
+++ b/exercises/nucleotide-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/ocr-numbers/stack.yaml
+++ b/exercises/ocr-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/octal/stack.yaml
+++ b/exercises/octal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/palindrome-products/stack.yaml
+++ b/exercises/palindrome-products/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/pangram/stack.yaml
+++ b/exercises/pangram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/parallel-letter-frequency/stack.yaml
+++ b/exercises/parallel-letter-frequency/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/pascals-triangle/stack.yaml
+++ b/exercises/pascals-triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/perfect-numbers/stack.yaml
+++ b/exercises/perfect-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/phone-number/stack.yaml
+++ b/exercises/phone-number/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/pig-latin/stack.yaml
+++ b/exercises/pig-latin/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/poker/stack.yaml
+++ b/exercises/poker/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/pov/stack.yaml
+++ b/exercises/pov/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/prime-factors/stack.yaml
+++ b/exercises/prime-factors/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/protein-translation/stack.yaml
+++ b/exercises/protein-translation/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/proverb/stack.yaml
+++ b/exercises/proverb/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/pythagorean-triplet/stack.yaml
+++ b/exercises/pythagorean-triplet/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/queen-attack/stack.yaml
+++ b/exercises/queen-attack/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/rail-fence-cipher/stack.yaml
+++ b/exercises/rail-fence-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/raindrops/stack.yaml
+++ b/exercises/raindrops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/resistor-color-duo/stack.yaml
+++ b/exercises/resistor-color-duo/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/resistor-color-trio/stack.yaml
+++ b/exercises/resistor-color-trio/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/rna-transcription/stack.yaml
+++ b/exercises/rna-transcription/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/robot-name/stack.yaml
+++ b/exercises/robot-name/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/robot-simulator/stack.yaml
+++ b/exercises/robot-simulator/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/roman-numerals/stack.yaml
+++ b/exercises/roman-numerals/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/rotational-cipher/stack.yaml
+++ b/exercises/rotational-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/run-length-encoding/stack.yaml
+++ b/exercises/run-length-encoding/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/saddle-points/stack.yaml
+++ b/exercises/saddle-points/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/say/stack.yaml
+++ b/exercises/say/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/scrabble-score/stack.yaml
+++ b/exercises/scrabble-score/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/secret-handshake/stack.yaml
+++ b/exercises/secret-handshake/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/series/stack.yaml
+++ b/exercises/series/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/sgf-parsing/stack.yaml
+++ b/exercises/sgf-parsing/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/sieve/stack.yaml
+++ b/exercises/sieve/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/simple-cipher/stack.yaml
+++ b/exercises/simple-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/simple-linked-list/stack.yaml
+++ b/exercises/simple-linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/space-age/stack.yaml
+++ b/exercises/space-age/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/spiral-matrix/stack.yaml
+++ b/exercises/spiral-matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/strain/stack.yaml
+++ b/exercises/strain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/sublist/stack.yaml
+++ b/exercises/sublist/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/sum-of-multiples/stack.yaml
+++ b/exercises/sum-of-multiples/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/transpose/stack.yaml
+++ b/exercises/transpose/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/triangle/stack.yaml
+++ b/exercises/triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/trinary/stack.yaml
+++ b/exercises/trinary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/twelve-days/stack.yaml
+++ b/exercises/twelve-days/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/word-count/stack.yaml
+++ b/exercises/word-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/wordy/stack.yaml
+++ b/exercises/wordy/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/yacht/stack.yaml
+++ b/exercises/yacht/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/zebra-puzzle/stack.yaml
+++ b/exercises/zebra-puzzle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21

--- a/exercises/zipper/stack.yaml
+++ b/exercises/zipper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.8
+resolver: lts-16.21


### PR DESCRIPTION
Last updated 5 months ago in #905.

lts-15.8 uses GHC 8.8.3.

lts-16.21 uses GHC 8.8.4.

https://www.stackage.org/diff/lts-15.8/lts-16.21

I have confirmed that no README check is needed