### PR TITLE
Make nightly CI succeed

### DIFF
--- a/exercises/change/examples/success-standard/src/Change.hs
+++ b/exercises/change/examples/success-standard/src/Change.hs
@@ -25,5 +25,5 @@ findFewestCoins target coins = minChange target sortedCoins [] Nothing
     addCoin _ _ _ = id
 
     dropCoin target' (_:restCoins) = minChange target' restCoins
-    dropCoin _ _ = flip const
+    dropCoin _ _ = const id
 

--- a/exercises/list-ops/package.yaml
+++ b/exercises/list-ops/package.yaml
@@ -1,5 +1,5 @@
 name: list-ops
-version: 2.4.0.8
+version: 2.4.0.9
 
 dependencies:
   - base

--- a/exercises/list-ops/test/Tests.hs
+++ b/exercises/list-ops/test/Tests.hs
@@ -79,7 +79,7 @@ specs = do
         foldl' (flip (:)) [] "asdf" `shouldBe` "fdsa"
       -- Track-specific test
       it "is accumulator-strict (use seq or BangPatterns)" $
-        evaluate (foldl' (flip const) () [throw StrictException, ()])
+        evaluate (foldl' (const id) () [throw StrictException, ()])
         `shouldThrow` (== StrictException)
 
     describe "foldr" $ do


### PR DESCRIPTION
Currently it seems that the only reason why 'nightly' CI fails is because of a few HLint warnings:

https://travis-ci.org/github/exercism/haskell/jobs/743533300

This PR consists of two commits that change `flip const` into `const id`.

Since one file is a test/Tests.hs, the [SERIAL component](https://github.com/exercism/haskell/#exercise-versioning) is bumped.