### PR TITLE
Add property tests to resistor-color-duo (remake)

### DIFF
--- a/exercises/resistor-color-duo/.meta/hints.md
+++ b/exercises/resistor-color-duo/.meta/hints.md
@@ -8,3 +8,32 @@ value :: (Color, Color) -> Int
 
 that only accepts two colors and produces the resistor's numeric value
 component of its resistance.
+
+**Bonus - Property Testing:**
+
+This exercise is a good opportunity to write some [property tests](https://en.wikipedia.org/wiki/Property_testing). If you haven't written any before here are some resources:
+
+1. [School of Haskell](https://www.schoolofhaskell.com/user/pbv/an-introduction-to-quickcheck-testing).
+2. [Real world Haskell](http://book.realworldhaskell.org/read/testing-and-quality-assurance.html)
+
+We have provided one sample property test in the [test file](test/Tests.hs). We use the [QuickCheck](https://hackage.haskell.org/package/QuickCheck) library, but there are [others](http://hackage.haskell.org/package/hedgehog) as well, feel free to play around.
+
+Few properties that can be tested:
+
+* `value (x, y) >= 10` for all x except Black and all y
+
+* `show (value (x, y)) == reverse (show (value (y, x)))` for all x, y except Black.
+
+* (Color, Color) is isomorphic to [0..99] (or: all colors have a unique value).
+
+* Associativity: Kind of tricky because you can't get the value of a single Color:
+
+```haskell
+value (k, x) <= value (k, y) && value (k, y) <= value (k, z)
+  ⇒ value (k, x) <= value (k, z)
+
+value (x, k) <= value (y, k) && value (y, k) <= value (z, k)
+  ⇒ value (k, x) <= value (k, z)
+```
+
+Can you think of any other properties?

--- a/exercises/resistor-color-duo/.meta/hints.md
+++ b/exercises/resistor-color-duo/.meta/hints.md
@@ -16,24 +16,12 @@ This exercise is a good opportunity to write some [property tests](https://en.wi
 1. [School of Haskell](https://www.schoolofhaskell.com/user/pbv/an-introduction-to-quickcheck-testing).
 2. [Real world Haskell](http://book.realworldhaskell.org/read/testing-and-quality-assurance.html)
 
-We have provided one sample property test in the [test file](test/Tests.hs). We use the [QuickCheck](https://hackage.haskell.org/package/QuickCheck) library, but there are [others](http://hackage.haskell.org/package/hedgehog) as well, feel free to play around.
+We have provided one sample QuickCheck property test in the test file.
 
-Few properties that can be tested:
+Examples of properties that can be tested:
 
-* `value (x, y) >= 10` for all x except Black and all y
+- `value (x, y) >= 10` for all `(x, y)` where `x` isn't `Black`
 
-* `show (value (x, y)) == reverse (show (value (y, x)))` for all x, y except Black.
+- Calling `show` on `value (x, y)` produces the `reverse` String of calling `show` on `value (y, x)`.
 
-* (Color, Color) is isomorphic to [0..99] (or: all colors have a unique value).
-
-* Associativity: Kind of tricky because you can't get the value of a single Color:
-
-```haskell
-value (k, x) <= value (k, y) && value (k, y) <= value (k, z)
-  ⇒ value (k, x) <= value (k, z)
-
-value (x, k) <= value (y, k) && value (y, k) <= value (z, k)
-  ⇒ value (k, x) <= value (k, z)
-```
-
-Can you think of any other properties?
+- All colors have unique names. (For any two colors, if the colors are different, so are their names.)

--- a/exercises/resistor-color-duo/README.md
+++ b/exercises/resistor-color-duo/README.md
@@ -44,6 +44,35 @@ value :: (Color, Color) -> Int
 that only accepts two colors and produces the resistor's numeric value
 component of its resistance.
 
+**Bonus - Property Testing:**
+
+This exercise is a good opportunity to write some [property tests](https://en.wikipedia.org/wiki/Property_testing). If you haven't written any before here are some resources:
+
+1. [School of Haskell](https://www.schoolofhaskell.com/user/pbv/an-introduction-to-quickcheck-testing).
+2. [Real world Haskell](http://book.realworldhaskell.org/read/testing-and-quality-assurance.html)
+
+We have provided one sample property test in the [test file](test/Tests.hs). We use the [QuickCheck](https://hackage.haskell.org/package/QuickCheck) library, but there are [others](http://hackage.haskell.org/package/hedgehog) as well, feel free to play around.
+
+Few properties that can be tested:
+
+* `value (x, y) >= 10` for all x except Black and all y
+
+* `show (value (x, y)) == reverse (show (value (y, x)))` for all x, y except Black.
+
+* (Color, Color) is isomorphic to [0..99] (or: all colors have a unique value).
+
+* Associativity: Kind of tricky because you can't get the value of a single Color:
+
+```haskell
+value (k, x) <= value (k, y) && value (k, y) <= value (k, z)
+  ⇒ value (k, x) <= value (k, z)
+
+value (x, k) <= value (y, k) && value (y, k) <= value (z, k)
+  ⇒ value (k, x) <= value (k, z)
+```
+
+Can you think of any other properties?
+
 
 
 ## Getting Started

--- a/exercises/resistor-color-duo/README.md
+++ b/exercises/resistor-color-duo/README.md
@@ -1,18 +1,18 @@
 # Resistor Color Duo
 
-If you want to build something using a Raspberry Pi, you'll probably use _resistors_. 
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
 For this exercise, you need to know two things about them:
 
 * Each resistor has a resistance value.
 * Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
 
-To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. 
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
 Each band has a position and a numeric value.
 
-The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number. 
+The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
 For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
 
-In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands. 
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands.
 The program will take color names as input and output a two digit number, even if the input is more than two colors!
 
 The band colors are encoded as follows:
@@ -51,27 +51,15 @@ This exercise is a good opportunity to write some [property tests](https://en.wi
 1. [School of Haskell](https://www.schoolofhaskell.com/user/pbv/an-introduction-to-quickcheck-testing).
 2. [Real world Haskell](http://book.realworldhaskell.org/read/testing-and-quality-assurance.html)
 
-We have provided one sample property test in the [test file](test/Tests.hs). We use the [QuickCheck](https://hackage.haskell.org/package/QuickCheck) library, but there are [others](http://hackage.haskell.org/package/hedgehog) as well, feel free to play around.
+We have provided one sample QuickCheck property test in the test file.
 
-Few properties that can be tested:
+Examples of properties that can be tested:
 
-* `value (x, y) >= 10` for all x except Black and all y
+- `value (x, y) >= 10` for all `(x, y)` where `x` isn't `Black`
 
-* `show (value (x, y)) == reverse (show (value (y, x)))` for all x, y except Black.
+- Calling `show` on `value (x, y)` produces the `reverse` String of calling `show` on `value (y, x)`.
 
-* (Color, Color) is isomorphic to [0..99] (or: all colors have a unique value).
-
-* Associativity: Kind of tricky because you can't get the value of a single Color:
-
-```haskell
-value (k, x) <= value (k, y) && value (k, y) <= value (k, z)
-  ⇒ value (k, x) <= value (k, z)
-
-value (x, k) <= value (y, k) && value (y, k) <= value (z, k)
-  ⇒ value (k, x) <= value (k, z)
-```
-
-Can you think of any other properties?
+- All colors have unique names. (For any two colors, if the colors are different, so are their names.)
 
 
 

--- a/exercises/resistor-color-duo/examples/success-standard/package.yaml
+++ b/exercises/resistor-color-duo/examples/success-standard/package.yaml
@@ -14,3 +14,4 @@ tests:
     dependencies:
       - resistor-color-duo
       - hspec
+      - QuickCheck

--- a/exercises/resistor-color-duo/examples/success-standard/src/ResistorColors.hs
+++ b/exercises/resistor-color-duo/examples/success-standard/src/ResistorColors.hs
@@ -11,7 +11,7 @@ data Color =
   | Violet
   | Grey
   | White
-  deriving (Eq, Show)
+  deriving (Eq, Show, Enum, Bounded)
 
 convert :: Color -> Int
 convert Black = 0

--- a/exercises/resistor-color-duo/package.yaml
+++ b/exercises/resistor-color-duo/package.yaml
@@ -1,5 +1,5 @@
 name: resistor-color-duo
-version: 2.1.0.3
+version: 2.1.0.4
 
 dependencies:
   - base
@@ -19,3 +19,4 @@ tests:
     dependencies:
       - resistor-color-duo
       - hspec
+      - QuickCheck

--- a/exercises/resistor-color-duo/src/ResistorColors.hs
+++ b/exercises/resistor-color-duo/src/ResistorColors.hs
@@ -11,7 +11,7 @@ data Color =
   | Violet
   | Grey
   | White
-  deriving (Eq, Show)
+  deriving (Eq, Show, Enum, Bounded)
 
 value :: (Color, Color) -> Int
 value (a, b) = error "You need to implement this function."

--- a/exercises/resistor-color-duo/test/Tests.hs
+++ b/exercises/resistor-color-duo/test/Tests.hs
@@ -1,19 +1,32 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE RecordWildCards #-}
 
-import Data.Foldable     (for_)
-import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Data.Foldable              (for_)
+import Test.Hspec                 (Spec, describe, context, it, shouldBe)
+import Test.Hspec.Runner          (configFastFail, defaultConfig, hspecWith)
+import Test.QuickCheck            (property)
+import Test.QuickCheck.Gen        (oneof)
+import Test.QuickCheck.Arbitrary
 
 import ResistorColors (Color(..), value)
+
+instance Arbitrary Color where
+  arbitrary = oneof $ map return [Black, Brown, Red, Orange, Yellow, Green, Blue, Violet, Grey, White]
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
 
 specs :: Spec
-specs = describe "value" $ for_ cases test
-  where
+specs = describe "value" $ do
+  context "equality tests" $ for_ cases test
 
+  context "property tests" $
+    it "all values starting with Black are single digit" $ property $
+      \color -> value (Black, color) < 10
+    -- Add more property tests here
+
+  where
     test Case{..} = it explanation assertion
       where
         explanation = unwords [show input, "-", description]

--- a/exercises/resistor-color-duo/test/Tests.hs
+++ b/exercises/resistor-color-duo/test/Tests.hs
@@ -1,36 +1,33 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE RecordWildCards #-}
 
 import Data.Foldable              (for_)
-import Test.Hspec                 (Spec, describe, context, it, shouldBe)
+import Test.Hspec                 (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner          (configFastFail, defaultConfig, hspecWith)
-import Test.QuickCheck            (property)
-import Test.QuickCheck.Gen        (oneof)
-import Test.QuickCheck.Arbitrary
+import Test.QuickCheck            (Gen, elements, forAll)
 
-import ResistorColors (Color(..), value)
-
-instance Arbitrary Color where
-  arbitrary = oneof $ map return [Black, Brown, Red, Orange, Yellow, Green, Blue, Violet, Grey, White]
+import ResistorColors (Color (..), value)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
 
 specs :: Spec
 specs = describe "value" $ do
-  context "equality tests" $ for_ cases test
+  describe "equality tests" $ for_ cases test
 
-  context "property tests" $
-    it "all values starting with Black are single digit" $ property $
-      \color -> value (Black, color) < 10
+  describe "property tests" $
+    it "all values starting with Black are single digit" $
+      forAll colorGen (\color -> value (Black, color) < 10)
+
     -- Add more property tests here
-
   where
     test Case{..} = it explanation assertion
       where
         explanation = unwords [show input, "-", description]
         assertion   = value input `shouldBe` expected
+
+colorGen :: Gen Color
+colorGen = elements [minBound ..]
 
 data Case = Case { description :: String
                  , input       :: (Color, Color)


### PR DESCRIPTION
This PR resumes the work of and closes #907.

#907 appears to not have "Allow edits by maintainers" enabled, so I cannot push any changes there.

The only difference that is not already discussed in the feedback of #907 is that `instance Arbitrary Color` was replaced with `forAll colorGen`. This removes the need for suppressing orphan instances and is generally a better way to express the relationship between properties and particular generators. For more background on this choice, read the parts of the FPComplete article [QuickCheck, Hedgehog, Validity](https://www.fpcomplete.com/blog/quickcheck-hedgehog-validity/) that isn't about shrinking.

This PR could be squash-merged since my commit message is a bit meta.

The important part is addressing the actual change of #907.