### PR TITLE
ensure-readmes-are-updated: must quote $configlet

### DIFF
--- a/bin/ensure-readmes-are-updated.sh
+++ b/bin/ensure-readmes-are-updated.sh
@@ -13,10 +13,10 @@ if git log master..HEAD | grep -q "$override_message"; then
 fi
 
 configlet=$(which configlet)
-if [ ! -x $configlet ]; then
+if [ ! -x "$configlet" ]; then
     configlet=bin/configlet
 fi
-if [ ! -x $configlet ]; then
+if [ ! -x "$configlet" ]; then
    echo "Improper configuration; configlet should exist in bin/ when this script is run"
    echo "Ping a Haskell track maintainer to fix this"
    exit 1


### PR DESCRIPTION
Otherwise, in the case where `which configlet` has empty output, then
the line `if [ ! -x $configlet ]` is results in `if [ ! -x ]`. Observe
the following:

    $ cat a.sh
    if [ ! -x ]; then
      echo "NOT EXECUTABLE"
    else
      echo "EXECUTABLE"
    fi
    $ sh a.sh
    EXECUTABLE

That means, were $configlet not quoted, configlet not being in the PATH
would mean that the script would proceed (not exit) with $configlet
being empty string. That eventually results in a "generate not found" on
line 38 (which starts with `$configlet generate`).

Compare to:

    $ cat b.sh
    if [ ! -x "" ]; then
      echo "NOT EXECUTABLE"
    else
      echo "EXECUTABLE"
    fi
    $ sh b.sh
    NOT EXECUTABLE

This is the correct behavior, so we must quote $configlet making
"$configlet".