### PR TITLE
remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false              # Use the container-based infrastructure.
-language: bash
-install:
- - /bin/true
-script:
- - /bin/true


### PR DESCRIPTION
We've done all of the following:

* moved from Travis to GitHub Actions in
  https://github.com/exercism/haskell/pull/930
* tested that everything works on GitHub Actions in
  https://github.com/exercism/haskell/pull/930
* requested and received confirmation that Travis CI is no longer a
  required check, and GitHub Actions is required, in
  https://github.com/exercism/haskell/issues/921

We're ready to remove the Travis CI config (which at this point is just
running /bin/true anyway so not doing anything useful)