### PR TITLE
Add key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -1108,7 +1108,7 @@
     },
     {
       "title": "Algebraic data types",
-      "content": "In combination with pattern matching, algebraic data types provide a high degree of convenience and safety.",
+      "content": "Using pattern matching, algebraic data types provide a high degree of convenience and safety.",
       "icon": "features-algebraic-data-types"
     }
   ],

--- a/config.json
+++ b/config.json
@@ -1109,7 +1109,7 @@
     {
       "title": "Algebraic data types",
       "content": "In combination with pattern matching, algebraic data types provide a high degree of convenience and safety.",
-      "icon": "features-product-types"
+      "icon": "features-algebraic-data-types"
     }
   ],
   "tags": []

--- a/config.json
+++ b/config.json
@@ -1080,6 +1080,37 @@
     ]
   },
   "concepts": [],
-  "key_features": [],
+  "key_features": [
+    {
+      "title": "Purely functional",
+      "content": "Referential transparency make functions more predictable and composable",
+      "icon": "..."
+    },
+    {
+      "title": "Non-strict",
+      "content": "Non-strict evaluation allows for infinite data structures",
+      "icon": "..."
+    },
+    {
+      "title": "Strong, static typing",
+      "content": "More program errors are caught before the program is run",
+      "icon": "..."
+    },
+    {
+      "title": "Type inference",
+      "content": "Type strictness without annotations makes code lighter to read",
+      "icon": "..."
+    },
+    {
+      "title": "Type classes",
+      "content": "Type-safe operator overloading",
+      "icon": "..."
+    },
+    {
+      "title": "Algebraic data types",
+      "content": "In combination with pattern matching, algebraic data types provide a high degree of convenience and safety.",
+      "icon": "..."
+    }
+  ],
   "tags": []
 }

--- a/config.json
+++ b/config.json
@@ -1084,32 +1084,32 @@
     {
       "title": "Purely functional",
       "content": "Referential transparency make functions more predictable and composable",
-      "icon": "..."
+      "icon": "features-functional"
     },
     {
       "title": "Non-strict",
       "content": "Non-strict evaluation allows for infinite data structures",
-      "icon": "..."
+      "icon": "features-lazy"
     },
     {
       "title": "Strong, static typing",
       "content": "More program errors are caught before the program is run",
-      "icon": "..."
+      "icon": "features-strongly-typed"
     },
     {
       "title": "Type inference",
       "content": "Type strictness without annotations makes code lighter to read",
-      "icon": "..."
+      "icon": "features-type-inference"
     },
     {
       "title": "Type classes",
       "content": "Type-safe operator overloading",
-      "icon": "..."
+      "icon": "features-type-classes"
     },
     {
       "title": "Algebraic data types",
       "content": "In combination with pattern matching, algebraic data types provide a high degree of convenience and safety.",
-      "icon": "..."
+      "icon": "features-product-types"
     }
   ],
   "tags": []


### PR DESCRIPTION
This uses the `features-functional`, `features-lazy`, and `features-strongly-typed` icons present in the example text:

https://github.com/exercism/docs/blob/main/anatomy/tracks/config-json.md#key-features

The three others, `features-type-inference`, `features-type-classes`, and ~`features-product-types`~ `features-algebraic-data-types` are proposals to have icons made.

Note that they don't exactly correspond, but close enough:

- "Purely functional" becomes `features-functional`, not exact but close.
- "Non-strict" becomes `features-lazy`, obligatory [non-strict vs. lazy](https://wiki.haskell.org/Lazy_vs._non-strict) remark
- "Strong, static typic" becomes `features-strongly-typed`, quite close
- `features-type-inference` was made up by me
- `features-type-classes` was made up by me (could have been `features-typed-overloading`, but this is more precise)
- ~`features-product-types`~ was made up by me (~could have been~ *is* `features-algebraic-data-types`)

Note that:
- These were proposed in #938.
- CI is currently broken, so perhaps wait with merging this until CI has been fixed.
- I have not assessed how much CI / configlet v3 checks the validity of this.
- When merging, this should be squash merged.

@ErikSchierboom: How does this process work?