### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Haskell is a general-purpose programming language known for being purely functional, non-strict with strong static typing and for having type inference.
 
 **Purely functional** means that you don't update variables or modify state.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 ## Installing Stack
 
 If you don't have a recent Stack version installed in your system, follow the

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Haskell is a purely functional language, which is a paradigm fundamentally different than the more
 commonly taught [object oriented approach](https://en.wikipedia.org/wiki/Object-oriented_programming). Because of this,
 learning Haskell can feel different than simply picking up another language.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 * The [#haskell](http://webchat.freenode.net/?channels=haskell) IRC channel on irc.freenode.net whose goal is to "encourage learning and discussion of Haskell, functional programming, and programming in general". More information about the IRC channel can be found on [the Haskell Wiki page for the channel](https://wiki.haskell.org/IRC_channel).
 * [Hoogle](https://www.haskell.org/hoogle/) is a Haskell API search engine. This allows you to look up what a function does if all you know is its name. Perhaps more interestingly, it also supports searching by type signature: If you want to know what functions have the type signature [(a -> b) -> [a] -> [b]](https://www.haskell.org/hoogle/?hoogle=%28a+-%3E+b%29+-%3E+[a]+-%3E+[b]), Hoogle helps you find out!
 * [Stack Overflow](http://stackoverflow.com/questions/tagged/haskell) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -15,7 +15,7 @@ To run the tests on every file save, run this command instead:
 stack test --file-watch
 ```
 
-#### If you get an error message like this...
+### If you get an error message like this...
 
 ```
 No .cabal file found in directory
@@ -24,7 +24,7 @@ No .cabal file found in directory
 You are probably running an old stack version and need
 to upgrade it.
 
-#### Otherwise, if you get an error message like this...
+### Otherwise, if you get an error message like this...
 
 ```
 No compiler found, expected minor version match with...
@@ -70,7 +70,7 @@ which you can use as a starting point for your solution.
 Just keep in mind that this *stub* is there just for you to get started.
 Feel free to change it completely if you think it is the right thing to do.
 
-#### Using packages
+### Using packages
 
 If you want to use some packages to write a more elegant solution, just
 add the packages to your solution's dependencies in `package.yaml`:
@@ -84,7 +84,7 @@ library:
     - bar
 ```
 
-#### Running *GHCi*
+### Running *GHCi*
 
 If you want to play with your solution in GHCi, just run the command:
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 
 ## Running Tests
 

--- a/exercises/practice/acronym/.docs/instructions.append.md
+++ b/exercises/practice/acronym/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 This exercise works with textual data. For historical reasons, Haskell's
 `String` type is synonymous with `[Char]`, a list of characters. For more

--- a/exercises/practice/allergies/.docs/instructions.append.md
+++ b/exercises/practice/allergies/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise you need to to create the data type `Allergen`,
 with `Eq` and `Show` instances, and implement the following functions:

--- a/exercises/practice/alphametics/.docs/instructions.append.md
+++ b/exercises/practice/alphametics/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 You can solve this exercise with a brute force algorithm, but this will possibly have a poor runtime performance.
 Try to find a more sophisticated solution. Hint: You could try the column-wise addition algorithm that is usually taught in high school.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise you need to implement the function `anagramsFor`,
 that takes a *word* and a group of *words*, returning the ones that are

--- a/exercises/practice/atbash-cipher/.docs/instructions.append.md
+++ b/exercises/practice/atbash-cipher/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 You need to implement the `decode` and `encode` functions, which decode and encode a `String` using an Atbash cipher.
 You can use the provided signature if you are unsure about the types, but don't let it restrict your creativity.

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise you need to implement the following functions:
 

--- a/exercises/practice/beer-song/.docs/instructions.append.md
+++ b/exercises/practice/beer-song/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 This exercise is about [code refactoring](https://en.wikipedia.org/wiki/Refactoring),
 so we are providing you with a solution that already passes the tests.

--- a/exercises/practice/binary-search-tree/.docs/instructions.append.md
+++ b/exercises/practice/binary-search-tree/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise you need to create the data type `BST`,
 with `Eq` and `Show` instances, and implement the functions:

--- a/exercises/practice/binary-search/.docs/instructions.append.md
+++ b/exercises/practice/binary-search/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 Haskell has support for many types of arrays. This exercise uses immutable,
 boxed, non-strict arrays from `Data.Array`. You can read more about the use of

--- a/exercises/practice/bob/.docs/instructions.append.md
+++ b/exercises/practice/bob/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 You need to implement the `responseFor` function that returns Bob's response
 for a given input. You can use the provided signature if you are unsure

--- a/exercises/practice/bowling/.docs/instructions.append.md
+++ b/exercises/practice/bowling/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise you need to implement the function `score`,
 that takes a sequence of bowling *rolls* and returns the final score or

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 It's a 24 hour clock going from "00:00" to "23:59".
 

--- a/exercises/practice/custom-set/.docs/instructions.append.md
+++ b/exercises/practice/custom-set/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to create the data type `CustomSet`,
 with `Eq` and `Show` instances, and implement the following functions:

--- a/exercises/practice/diamond/.docs/instructions.append.md
+++ b/exercises/practice/diamond/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 You need to implement the `diamond` function which prints a diamond starting at
 `A` with the given character at its widest points. You can use the provided

--- a/exercises/practice/dnd-character/.docs/instructions.append.md
+++ b/exercises/practice/dnd-character/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 This exercise uses QuickCheck generators. Here are some resources to get started:
 

--- a/exercises/practice/etl/.docs/instructions.append.md
+++ b/exercises/practice/etl/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 This exercise works with textual data. For historical reasons, Haskell's
 `String` type is synonymous with `[Char]`, a list of characters. For more

--- a/exercises/practice/food-chain/.docs/instructions.append.md
+++ b/exercises/practice/food-chain/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 This exercise is about [code refactoring](https://en.wikipedia.org/wiki/Refactoring),
 so we are providing you with a solution that already passes the tests.

--- a/exercises/practice/forth/.docs/instructions.append.md
+++ b/exercises/practice/forth/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to create the data type `ForthState`
 and implement the following functions:

--- a/exercises/practice/go-counting/.docs/instructions.append.md
+++ b/exercises/practice/go-counting/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to implement the following functions:
 

--- a/exercises/practice/grade-school/.docs/instructions.append.md
+++ b/exercises/practice/grade-school/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise you need to create the data type `School`
 and implement the following functions:

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to implement the `hello` function.
 

--- a/exercises/practice/house/.docs/instructions.append.md
+++ b/exercises/practice/house/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 This exercise is about [code refactoring](https://en.wikipedia.org/wiki/Refactoring),
 so we are providing you with a solution that already passes the tests.

--- a/exercises/practice/isogram/.docs/instructions.append.md
+++ b/exercises/practice/isogram/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 This exercise works with textual data. For historical reasons, Haskell's
 `String` type is synonymous with `[Char]`, a list of characters. For more

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise you need to implement the function `isLeapYear`
 that takes a year and determines whether it is a leap year.

--- a/exercises/practice/linked-list/.docs/instructions.append.md
+++ b/exercises/practice/linked-list/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to create the data type `Deque`
 and implement the following functions:

--- a/exercises/practice/matrix/.docs/instructions.append.md
+++ b/exercises/practice/matrix/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to create the data type `Matrix`,
 with `Eq` and `Show` instances, and implement the following functions:

--- a/exercises/practice/meetup/.docs/instructions.append.md
+++ b/exercises/practice/meetup/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to implement the `meetupDay` function.
 

--- a/exercises/practice/octal/.docs/instructions.append.md
+++ b/exercises/practice/octal/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 For the appropriate amount of challenge here, you should only
 use functionality present in Prelude. Try not to use Data.List,

--- a/exercises/practice/palindrome-products/.docs/instructions.append.md
+++ b/exercises/practice/palindrome-products/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To solve this exercise you need to implement these two functions:
 

--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -4,6 +4,6 @@ Your code should contain a frequency :: Int -> [Text] -> Map Char Int
 function which accepts a number of workers to use in parallel and a list
 of texts and returns the total frequency of each letter in the text.
 
-### Benchmark
+## Benchmark
 
 Check how changing number of workers affects performance of your solution by running the benchmark. Use `stack bench` to run it. Feel free to modify `bench/Benchmark.hs` to explore your solution's performance on different inputs.

--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 Your code should contain a frequency :: Int -> [Text] -> Map Char Int
 function which accepts a number of workers to use in parallel and a list

--- a/exercises/practice/pig-latin/.docs/instructions.append.md
+++ b/exercises/practice/pig-latin/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 The unit tests provide examples of words. Try and cluster consonants
 independent of the specific combinations of consonants in the unit tests.

--- a/exercises/practice/queen-attack/.docs/instructions.append.md
+++ b/exercises/practice/queen-attack/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to implement the following functions:
 

--- a/exercises/practice/raindrops/.docs/instructions.append.md
+++ b/exercises/practice/raindrops/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 You need to implement the `convert` function that returns number converted to
 raindrop sound. You can use the provided signature if you are unsure

--- a/exercises/practice/resistor-color-duo/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color-duo/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 You need to implement the function
 

--- a/exercises/practice/resistor-color-trio/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color-trio/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 You need to implement the functions `label` and `ohms`. You can use the
 provided signature for `label`, but don't let it restrict your creativity.

--- a/exercises/practice/rna-transcription/.docs/instructions.append.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.append.md
@@ -1,1 +1,3 @@
+# Instructions append
+
 Given invalid output, your program should return the first invalid character.

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to create the data type `Robot`,
 as a mutable variable, and the data type `RunState`. You also need to

--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to create the data type `Robot`,
 and implement the following functions:

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise you need to implement the function `numerals`,
 that *maybe* converts a number to a *string* representing a roman numeral.

--- a/exercises/practice/rotational-cipher/.docs/instructions.append.md
+++ b/exercises/practice/rotational-cipher/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 You need to implement the `rotate` function, which takes an `Int` and a `String`, and then encodes it using an rotational cipher.
 You can use the provided signature if you are unsure about the types, but don't let it restrict your creativity.

--- a/exercises/practice/series/.docs/instructions.append.md
+++ b/exercises/practice/series/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise you need to implement the function `slices`,
 that takes a *text* and returns the subsequences of digits with a

--- a/exercises/practice/sgf-parsing/.docs/instructions.append.md
+++ b/exercises/practice/sgf-parsing/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 The Sgf module should export a parseSgf module with the following signature:
 

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise, you need to create the data type `LinkedList`,
 and implement the following functions:

--- a/exercises/practice/space-age/.docs/instructions.append.md
+++ b/exercises/practice/space-age/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 In this exercise, we provided the definition of the
 [algebric data type](http://learnyouahaskell.com/making-our-own-types-and-typeclasses)

--- a/exercises/practice/sublist/.docs/instructions.append.md
+++ b/exercises/practice/sublist/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 The type
 [`Ordering`](http://hackage.haskell.org/package/base/docs/Data-Ord.html#t:Ordering)

--- a/exercises/practice/trinary/.docs/instructions.append.md
+++ b/exercises/practice/trinary/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 For the appropriate amount of challenge here, you should only
 use functionality present in Prelude. Try not to use Data.List,

--- a/exercises/practice/twelve-days/.docs/instructions.append.md
+++ b/exercises/practice/twelve-days/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 You need to implement the `recite` function which outputs the lyrics to
 'The Twelve Days of Christmas'. You can use the provided signature

--- a/exercises/practice/word-count/.docs/instructions.append.md
+++ b/exercises/practice/word-count/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 To complete this exercise you need to implement the function `wordCount`,
 that takes a *text* and returns how many times each *word* appears.

--- a/exercises/practice/wordy/.docs/instructions.append.md
+++ b/exercises/practice/wordy/.docs/instructions.append.md
@@ -1,3 +1,3 @@
-## Hints
+# Hints
 
 This is a perfect opportunity to learn some Attoparsec or Parsec!


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
