### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "a44dd1aa-f3a9-4350-8d44-060429b4c009",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Haskell locally",
+      "blurb": "Learn how to install Haskell locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "84a58d7d-5cec-40c7-9f20-7505a66a0ec4",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Haskell",
+      "blurb": "An overview of how to get started from scratch with Haskell"
+    },
+    {
+      "uuid": "ac018395-118e-4ac1-94f7-ff72df60dd00",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Haskell track",
+      "blurb": "Learn how to test your Haskell exercises on Exercism"
+    },
+    {
+      "uuid": "b8298278-68ce-4ecb-8111-0ce9df2a7921",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Haskell resources",
+      "blurb": "A collection of useful resources to help you master Haskell"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
