### PR TITLE
Mark sshine as alumnus

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -43,13 +43,13 @@
     },
     {
       "github_username": "sshine",
-      "alumnus": false,
-      "show_on_website": true,
+      "alumnus": true,
+      "show_on_website": false,
       "name": "Simon Shine",
       "link_text": "https://simonshine.dk",
       "link_url": "https://simonshine.dk",
       "avatar_url": null,
-      "bio": "I've been a classroom teacher in compilers and various functional languages for five years. Having pure functions and isolation of side-effects are fundamental to separation of concerns. Strong, static types, type inference and algebraic types are hard for me to live without."
+      "bio": null
     },
     {
       "github_username": "aimorris",


### PR DESCRIPTION
Originally submitted in #962, but closed because of the deletion of fork.

It seems that the resignation is intended because the fork has been deleted and sshine left the Exercism GitHub organisation.