### PR TITLE
exercise_readme: add 404 error

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -24,6 +24,15 @@ stack test
 No .cabal file found in directory
 ```
 
+or
+
+```
+RedownloadInvalidResponse Request {
+...
+}
+ "/home/username/.stack/build-plan/lts-xx.yy.yaml" (Response {responseStatus = Status {statusCode = 404, statusMessage = "Not Found"},
+```
+
 You are probably running an old stack version and need
 to upgrade it.
 


### PR DESCRIPTION
Seen in:
https://github.com/exercism/haskell/issues/912
https://github.com/exercism/exercism/issues/5504

With solution reported in the latter.

This PR shows the change I would like to make to the docs, but I am no longer sure whether this is the correct place to make this change. I can't really find evidence that this file is used.