### PR TITLE
tests: Use `yq eval` of yq 4.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
           key: ${{ steps.resolve-resolver.outputs.resolver }}-${{ steps.week-no.outputs.week-no }}-${{ hashFiles('exercises/**/package.yaml') }}
           restore-keys: ${{ steps.resolve-resolver.outputs.resolver }}-${{ steps.week-no.outputs.week-no }}-
 
-      - uses: actions/setup-haskell@v1
+      - uses: haskell/actions/setup@v1
         with:
           enable-stack: true
           stack-version: 'latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
           # because that would cause caches from differing LTSes to collide
           # (if we have updated the LTS version of all exercises between job runs).
           if [ "${{ matrix.resolver }}" = "lts-from-exercises" ]; then
-            resolver=$(yq read "$(ls -1 exercises/practice/*/stack.yaml | head -1)" resolver)
+            resolver=$(yq eval .resolver "$(ls -1 exercises/practice/*/stack.yaml | head -1)")
           else
             resolver=${{ matrix.resolver }}
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,7 +145,16 @@ jobs:
             export SET_RESOLVER="--resolver ${{ matrix.resolver }}"
           fi
 
-          for exercise in ${{ github.workspace }}/exercises/practice/*; do
-            time bin/test-stub $exercise
-            time bin/test-all-examples $exercise
-          done
+          if [ "${{ matrix.resolver }}" = "nightly" ]; then
+            # allow nightly to fail - note that continue-on-error is inadequate.
+            # https://github.com/actions/toolkit/issues/399
+            for exercise in ${{ github.workspace }}/exercises/practice/*; do
+              bin/warn-on-failure time bin/test-stub $exercise
+              bin/warn-on-failure time bin/test-all-examples $exercise
+            done
+          else
+            for exercise in ${{ github.workspace }}/exercises/practice/*; do
+              time bin/test-stub $exercise
+              time bin/test-all-examples $exercise
+            done
+          fi

--- a/bin/ensure-stack-resolvers-are-synced.sh
+++ b/bin/ensure-stack-resolvers-are-synced.sh
@@ -4,10 +4,10 @@
 
 differing_stack=""
 first_stack_yaml=$(ls -1 exercises/practice/*/stack.yaml | head -1)
-expected_stack=$(yq read "$first_stack_yaml" resolver)
+expected_stack=$(yq eval .resolver "$first_stack_yaml")
 echo "All exercises should have resolver $expected_stack"
 for exercise in $(git rev-parse --show-toplevel)/exercises/practice/*/ ; do
-    exercise_stack=$(yq read "$exercise/stack.yaml" resolver)
+    exercise_stack=$(yq eval .resolver "$exercise/stack.yaml")
     if ! [ "$exercise_stack" = "$expected_stack" ]; then
       differing_stack="$differing_stack $(basename "$exercise")"
     fi

--- a/bin/warn-on-failure
+++ b/bin/warn-on-failure
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if ! $@; then
+  # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message
+  echo "::warning::$@ failed"
+fi


### PR DESCRIPTION
The installed yq version was changed to 4.x.
https://mikefarah.gitbook.io/yq/v/v4.x/upgrading-from-v3
We must use eval instead of read, and we must say `.resolver` before the
list of files to read, rather than `resolver` after the list of files to
read.