### PR TITLE
Check whitespace in Crypto Square exercise

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -24,6 +24,15 @@ stack test
 No .cabal file found in directory
 ```
 
+or
+
+```
+RedownloadInvalidResponse Request {
+...
+}
+ "/home/username/.stack/build-plan/lts-xx.yy.yaml" (Response {responseStatus = Status {statusCode = 404, statusMessage = "Not Found"},
+```
+
 You are probably running an old stack version and need
 to upgrade it.
 

--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -34,7 +34,13 @@ RedownloadInvalidResponse Request {
 ```
 
 You are probably running an old stack version and need
-to upgrade it.
+to upgrade it. Try running:
+
+```bash
+stack upgrade
+```
+
+Or see other options for upgrading at [Stack documentation](https://docs.haskellstack.org/en/stable/install_and_upgrade/#upgrade).
 
 #### Otherwise, if you get an error message like this...
 

--- a/exercises/practice/crypto-square/examples/success-standard/src/CryptoSquare.hs
+++ b/exercises/practice/crypto-square/examples/success-standard/src/CryptoSquare.hs
@@ -6,6 +6,7 @@ import Data.List.Split (chunksOf)
 
 encode :: String -> String
 encode = unwords
+       . justify
        . transpose
        . (squareSize >>= chunksOf)
        . map toLower
@@ -13,3 +14,9 @@ encode = unwords
   where
     squareSize :: String -> Int
     squareSize = ceiling . (sqrt :: Double -> Double) . fromIntegral . length
+    justify :: [String] -> [String]
+    justify [] = []
+    justify (x:xs) = let width = length x in
+                         -- each row either needs zero or one spaces as padding,
+                         -- so there's no need to write (s ++ repeat ' ')
+                         x : map (\s -> take width (s ++ " ")) xs

--- a/exercises/practice/crypto-square/test/Tests.hs
+++ b/exercises/practice/crypto-square/test/Tests.hs
@@ -17,13 +17,12 @@ specs = describe "encode" $ for_ cases test
 
     test Case{..} = describe description $ do
 
-      let shouldMatchWords  = shouldBe        `on` words
-          shouldMatchString = shouldBe        `on` filter (not . isSpace)
+      let shouldMatchString = shouldBe        `on` filter (not . isSpace)
           shouldMatchChars  = shouldMatchList `on` filter (not . isSpace)
 
       it "normalizes the input"    $ encode input `shouldMatchChars`  expected
       it "reorders the characters" $ encode input `shouldMatchString` expected
-      it "groups the output"       $ encode input `shouldMatchWords`  expected
+      it "groups the output"       $ encode input `shouldBe`          expected
 
 data Case = Case { description :: String
                  , input       :: String

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,0 +1,15 @@
+# Help
+
+## Getting Started
+
+Please refer to the [installation](https://exercism.io/tracks/haskell/installation)
+and [learning](https://exercism.io/tracks/haskell/learning) help pages.
+
+## Feedback, Issues, Pull Requests
+
+The [exercism/haskell](https://github.com/exercism/haskell) repository on
+GitHub is the home for all of the Haskell exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue.  We'll do our best to help you!
+{{ with .Spec.Credits }}

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,0 +1,38 @@
+# Running the tests
+
+To run the test suite, execute the following command:
+
+```bash
+stack test
+```
+
+#### If you get an error message like this...
+
+```
+No .cabal file found in directory
+```
+
+You are probably running an old stack version and need
+to upgrade it.
+
+#### Otherwise, if you get an error message like this...
+
+```
+No compiler found, expected minor version match with...
+Try running "stack setup" to install the correct GHC...
+```
+
+Just do as it says and it will download and install
+the correct compiler version:
+
+```bash
+stack setup
+```
+
+# Running *GHCi*
+
+If you want to play with your solution in GHCi, just run the command:
+
+```bash
+stack ghci
+```

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -22,7 +22,13 @@ RedownloadInvalidResponse Request {
 ```
 
 You are probably running an old stack version and need
-to upgrade it.
+to upgrade it. Try running:
+
+```bash
+stack upgrade
+```
+
+Or see other options for upgrading at [Stack documentation](https://docs.haskellstack.org/en/stable/install_and_upgrade/#upgrade).
 
 #### Otherwise, if you get an error message like this...
 

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -12,6 +12,15 @@ stack test
 No .cabal file found in directory
 ```
 
+or
+
+```
+RedownloadInvalidResponse Request {
+...
+}
+ "/home/username/.stack/build-plan/lts-xx.yy.yaml" (Response {responseStatus = Status {statusCode = 404, statusMessage = "Not Found"},
+```
+
 You are probably running an old stack version and need
 to upgrade it.
 


### PR DESCRIPTION
Fixes https://github.com/exercism/haskell/issues/895. The canonical test data itself is fine; the problem was that the test suite was ignoring whitespace when comparing the actual result to the expected result.

(It's been a few months without a reply from the creator of that issue, so I figured it would be ok to fix it myself, since I ran into this today -- apologies if not!)