### PR TITLE
palindrome-products: fix typo ("your" -> "you") in instructions

### DIFF
--- a/exercises/practice/palindrome-products/.docs/instructions.append.md
+++ b/exercises/practice/palindrome-products/.docs/instructions.append.md
@@ -9,7 +9,7 @@ Both functions receive lower and upper factor limits, returning a pair
 `(value, [(factor1, factor2)])` containing the palindrome and its possible
 pairs of factors.
 
-Your can use the provided signatures if you are unsure about the types, but
+You can use the provided signatures if you are unsure about the types, but
 don't let them restrict your creativity.
 
 It's ok to return duplicates in the factors list, and the order of the factors


### PR DESCRIPTION
That was a gimme.