### PR TITLE
workflows: use reusable workflows for configlet and sync-labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -138,11 +138,6 @@
   description: "Make this PR count for hacktoberfest"
   color: "ff7518"
 
-# This label can be added to accept PRs as part of Hacktoberfest
-- name: "hacktoberfest-accepted"
-  description: "Make this PR count for hacktoberfest"
-  color: "ff7518"
-
 # This Exercism-wide label is added to all automatically created pull requests that help migrate/prepare a track for Exercism v3
 - name: "v3-migration 🤖"
   description: "Preparing for Exercism v3"

--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -1,0 +1,15 @@
+name: Configlet
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  configlet:
+    uses: exercism/github-actions/.github/workflows/configlet.yml@main

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -2,20 +2,18 @@ name: Tools
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     paths:
       - .github/labels.yml
       - .github/workflows/sync-labels.yml
-  schedule:
-    - cron: 0 0 1 * *
   workflow_dispatch:
+  schedule:
+    - cron: 0 0 1 * * # First day of each month
+
+permissions:
+  issues: write
 
 jobs:
   sync-labels:
-    name: Sync labels
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
-      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: exercism/github-actions/.github/workflows/labels.yml@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,12 +20,6 @@ jobs:
           # history.
           fetch-depth: 0
 
-      - name: Fetch configlet
-        uses: exercism/github-actions/configlet-ci@main
-
-      - name: Configlet Linter
-        run: configlet lint
-
       - name: Ensure practice exercise descriptions are synced
         run: bin/ensure-practice-exercise-descriptions-are-synced.sh
 


### PR DESCRIPTION
individual commit messages speak

for the Haskell track, the org-wide-files sync of https://github.com/exercism/org-wide-files/issues/155 must take the form of this PR, instead of #1051 .