### PR TITLE
Corrected the expected result of "-3 plus 7 multiplied by -2" from "-8" to "-17"

### DIFF
--- a/exercises/practice/wordy/test/Tests.hs
+++ b/exercises/practice/wordy/test/Tests.hs
@@ -78,7 +78,7 @@ cases = [ Case { description = "just a number"
                }
         , Case { description = "addition and multiplication"
                , input       = "What is -3 plus 7 multiplied by -2?"
-               , expected    = Just (-8)
+               , expected    = Just (-17)
                }
         , Case { description = "multiple division"
                , input       = "What is -12 divided by 2 divided by -3?"


### PR DESCRIPTION
The "wordy" test case "addition and multiplication" should expect "Just (-17)" instead of "Just (-8)".
The "*" operator has a higher precedence than "+".

