### PR TITLE
Update installation instructions to use GHCup

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,65 +1,82 @@
 # Installation
 
-## Installing Stack
 
-If you don't have a recent Stack version installed in your system, follow the
-[installation instructions](http://docs.haskellstack.org/en/stable/install_and_upgrade/)
-for your operating system. After completing the installation, test that you
-have installed it correctly by running this command in a terminal:
+## Get GHCup
 
-```bash
-stack --version
-```
+The recommended way of installing Haskell tools is through [GHCup][ghcup].
 
-If it outputs a Stack version equal to or greater than 1.1.2, then you have it
-installed correctly.
+With GHCup you can manage your installed compilers, project/package managers, and language server.
 
-## Installing GHC
 
-Stack will automatically download and install GHC (the Glasgow Haskell
-compiler) when it is required. You can start the installation and test
+## Install Stack
+
+For doing Exercism exercises you only need Stack.
+
+To install Stack, simply run the GHCup installation command or script and follow the defaults but specify that you would like to have Stack installed as well.
+
+Did you miss the opportunity? No worries: just run `ghcup install stack` afterwards.
+
+GHCup will install
+
+- **A compiler** (GHC: the Glasgow Haskell Compiler)
+  
+  Strictly speaking you do not need this for Exercism, but it comes in handy when you want to play with GHCi outside of exercise directories.
+
+- **Cabal**
+
+  A project/package manager. You do not need this for Exercism.
+
+- **Stack**
+
+  A project/package manager that you do need for Exercism. It will make sure you have the right compiler and libraries for each individual project (exercise).
+  
+To check that installation was successful, run the command `ghcup list` and/or `stack --version`.
+
+
+## Get the right GHC version
+
+Stack will automatically download and install GHC when it is required. You can start the installation and test
 by running the following command in a terminal:
 
 ```bash
-stack ghc
+# move into exercise directory
+cd /exercism/haskell/hello-world
+# start interactive environment
+stack ghc -- --version
 ```
 
-If this outputs something like `ghc: no input files`, GHC is installed
-correctly.
+If this outputs something like
 
-Note that there are other ways to install GHC on a system (like the
-[Haskell platform](https://www.haskell.org/platform/)), but for
-running the Exercism tests, a regular stack installation is most
-likely to work correctly.
-
-## Installing HLint (optional)
-
-HLint is a tool for suggesting possible improvements to Haskell code. These
-suggestions include ideas such as using alternative functions, simplifying
-code and spotting redundancies.
-
-You can use Stack to install HLint:
-
-```bash
-stack install hlint
+```
+The Glorious Glasgow Haskell Compilation System, version 8.8.4
 ```
 
-Check that it was installed correctly with:
+then GHC is installed correctly.
 
-```bash
-hlint --version
-```
 
-If you get the version in your terminal, you're done, otherwise, you
-probably need to add a missing directory to your path:
+## Set up your editor to work with Haskell
 
-- `%APPDATA%\local\bin`, if you are running *Windows*
-- `$HOME/.local/bin`, for other operating systems.
+Haskell support is provided by the Haskell Language Server (HLS).
 
-## Haskell IDEs and Plugins
 
-Using an <abbr title="Integrated Development Environment">IDE</abbr> can make it easier to factor your Haskell programs. There are several free and commercial IDEs available
-- [`atom-ide-haskell`](https://atom-haskell.github.io/) for Github's Atom editor
-- There are [a number of Haskell packages](https://medium.com/@dogwith1eye/setting-up-haskell-in-vs-code-on-macos-d2cc1ce9f60a) for Microsoft's Visual Studio Code editor.
-- [IntelliJ Haskell Plugin](https://github.com/rikvdkleij/intellij-haskell)
-- [Other Plugins](https://wiki.haskell.org/IDEs) referenced on the Haskell Wiki.
+### Visual Studio Code
+
+Just get [this extension][vscode-haskell]. It will use GHCup to install HLS automatically, after which you'll be all set.
+
+**Note:** with freshly downloaded exercises, HLS may have trouble starting up. If this happens, just run `stack test` and restart the language server.
+
+
+### Other editors
+
+See the [HLS documentation on editor configuration][hls-editor-config].
+
+
+[ghcup]:
+    https://www.haskell.org/ghcup/
+    "Get GHCup"
+[hls-editor-config]: 
+    https://haskell-language-server.readthedocs.io/en/latest/configuration.html#configuring-your-editor 
+    "Editor configuration for Haskell Language Server"
+[vscode-haskell]: 
+    https://marketplace.visualstudio.com/items?itemName=haskell.haskell 
+    "Haskell extension for VS Code"


### PR DESCRIPTION
These days the recommended installation method is to use GHCup.

The previous instructions (based on Stack) were not wrong, but the GHCup method is more general and should make it easier for students to do Haskell stuff outside of Exercism. I don't think the instructions are much more complicated.