### PR TITLE
Link to updated fork of Learn You A Haskell

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -65,7 +65,7 @@ So we'll start with this.
 module Calculator ( add ) where
 ```
 
-http://learnyouahaskell.com/modules#making-our-own-modules
+http://learnyouahaskell.github.io/modules#making-our-own-modules
 
 ## Comments
 
@@ -89,5 +89,5 @@ There is a [style guide](https://kowainik.github.io/posts/2019-02-06-style-guide
 
 ### Credits
 
-This concept guide borrows liberally from [Learn You a Haskell for Great Good!](http://learnyouahaskell.com/chapters),
+This concept guide borrows liberally from [Learn You a Haskell for Great Good!](http://learnyouahaskell.github.io/chapters),
 under [Creative Commons Attribution-Noncommercial-Share Alike 3.0 Unported License](http://creativecommons.org/licenses/by-nc-sa/3.0/)

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -65,7 +65,7 @@ So we'll start with this.
 module Calculator ( add ) where
 ```
 
-http://learnyouahaskell.com/modules#making-our-own-modules
+http://learnyouahaskell.github.io/modules#making-our-own-modules
 
 ## Comments
 
@@ -89,5 +89,5 @@ There is a [style guide](https://kowainik.github.io/posts/2019-02-06-style-guide
 
 ### Credits
 
-This concept guide borrows liberally from [Learn You a Haskell for Great Good!](http://learnyouahaskell.com/chapters),
+This concept guide borrows liberally from [Learn You a Haskell for Great Good!](http://learnyouahaskell.github.io/chapters),
 under [Creative Commons Attribution-Noncommercial-Share Alike 3.0 Unported License](http://creativecommons.org/licenses/by-nc-sa/3.0/)

--- a/concepts/basics/links.json
+++ b/concepts/basics/links.json
@@ -4,7 +4,7 @@
     "description": "Haskell indentation"
   },
   {
-    "url": "http://learnyouahaskell.com/chapters",
+    "url": "http://learnyouahaskell.github.io/chapters",
     "description": "Haskell tutorial"
   },
   {

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -13,5 +13,5 @@ The compiler can also tell you if a value has conflicting types in different par
 There are more than 10,000 free third-party packages available at [Hackage](https://hackage.haskell.org/), the Haskell community's central package archive,
 and you can download them using the [Stack](https://haskellstack.org/) tool that Exercism also uses.
 
-You can also read the free book [Learn You a Haskell for Great Good](http://learnyouahaskell.com/)
+You can also read the free book [Learn You a Haskell for Great Good](http://learnyouahaskell.github.io/)
 or follow the interactive tutorial at [tryhaskell.org](https://www.tryhaskell.org/).

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -8,7 +8,7 @@ Fortunately there are numerous resources which presume some programming knowledg
 as
 
   - An opinionated beginner's guide to Haskell ([2019](https://github.com/theindigamer/not-a-blog/blob/master/opinionated-haskell-guide-2019.md), [2018](https://lexi-lambda.github.io/blog/2018/02/10/an-opinionated-guide-to-haskell-in-2018/))
-  - the popular and free online book [Learn You a Haskell For Great Good!](http://learnyouahaskell.com/)
+  - the popular and free online book [Learn You a Haskell For Great Good!](http://learnyouahaskell.github.io/)
   - University of Glasgow's [Functional Programming in Haskell](https://www.futurelearn.com/courses/functional-programming-haskell) course
   - FP Complete's [School of Haskell](https://www.schoolofhaskell.com/)
   - the [Happy Learn Haskell Tutorial](http://www.happylearnhaskelltutorial.com/)

--- a/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
@@ -4,5 +4,5 @@
 
 # Modules and Indentation
 
-- [Declaring modules](http://learnyouahaskell.com/modules#making-our-own-modules)
+- [Declaring modules](http://learnyouahaskell.github.io/modules#making-our-own-modules)
 - [Indentation rules](https://en.wikibooks.org/wiki/Haskell/Indentation)

--- a/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
@@ -65,7 +65,7 @@ So we'll start with this.
 module Calculator ( add ) where
 ```
 
-http://learnyouahaskell.com/modules#making-our-own-modules
+http://learnyouahaskell.github.io/modules#making-our-own-modules
 
 ## Comments
 
@@ -85,5 +85,5 @@ Multiline comments are also possible with the `{-` and `-}` pair of opening and 
 
 ### Credits
 
-This exercise introduction borrows liberally from [Learn You a Haskell for Great Good!](http://learnyouahaskell.com/chapters),
+This exercise introduction borrows liberally from [Learn You a Haskell for Great Good!](http://learnyouahaskell.github.io/chapters),
 under [Creative Commons Attribution-Noncommercial-Share Alike 3.0 Unported License](http://creativecommons.org/licenses/by-nc-sa/3.0/)

--- a/exercises/practice/space-age/.docs/instructions.append.md
+++ b/exercises/practice/space-age/.docs/instructions.append.md
@@ -1,7 +1,7 @@
 # Hints
 
 In this exercise, we provided the definition of the
-[algebraic data type](http://learnyouahaskell.com/making-our-own-types-and-typeclasses)
+[algebraic data type](http://learnyouahaskell.github.io/making-our-own-types-and-typeclasses)
 named `Planet`.
 You need to implement the `ageOn` function, that calculates how many
 years old someone would be on a `Planet`, given an age in seconds.


### PR DESCRIPTION
The original [learnyouahaskell.com](http://learnyouahaskell.com/) has become a bit outdated, and moreover had some long standing issues. Therefore, an updated fork is maintained at [learnyouahaskell.github.io](https://learnyouahaskell.github.io/).

I changed every link to the original LYAH in the repo to point to the updated fork instead.