### PR TITLE
protein-translation: Add tests for invalid sequences

### DIFF
--- a/exercises/practice/protein-translation/test/Tests.hs
+++ b/exercises/practice/protein-translation/test/Tests.hs
@@ -116,6 +116,22 @@ cases = [ Case { description = "Methionine RNA sequence"
                , input       = "UGGUGUUAUUAAUGGUUU"
                , expected    = Just ["Tryptophan","Cysteine","Tyrosine"]
                }
+        , Case { description = "Translation fails on unknown codon"
+               , input       = "ABC"
+               , expected    = Nothing
+               }
+        , Case { description = "Translation stops if STOP codon before invalid codon"
+               , input       = "UAGABC"
+               , expected    = Just []
+               }
+        , Case { description = "Translation fails if codon is too short"
+               , input       = "AUGA"
+               , expected    = Nothing
+               }
+        , Case { description = "Translation stops if STOP codon before too short codon"
+               , input       = "UAGA"
+               , expected    = Just []
+               }
         ]
 
 -- baf663fecc756872af85e8ae6ed24f3f7cbb9388


### PR DESCRIPTION
The result type of the `proteins` function is `Maybe [String]` but all tests expect `Just`.
I added some tests that expect `Nothing` on an invalid input.