### PR TITLE
Exclude `stack.yaml.lock` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin/configlet.exe
 
 # exercism/haskell specific patterns
 *.cabal
+stack.yaml.lock
 
 # sorted default .gitignore from github/gitignore/Haskell.gitignore
 *.aux


### PR DESCRIPTION
`stack.yaml.lock` files are generated automatically when exercises are tested and during their development.

Alternatively we could exclude `*.lock` more generally, which I feel makes some sense but could also break in the future.