### PR TITLE
saddle-points/test: Do not use head on empty list

### DIFF
--- a/exercises/practice/saddle-points/test/Tests.hs
+++ b/exercises/practice/saddle-points/test/Tests.hs
@@ -18,7 +18,7 @@ specs = describe "saddlePoints" $ for_ cases test
       where
         assertion = saddlePoints matrix `shouldBe` expected
         rows      = length xss
-        columns   = length $ head xss
+        columns   = if null xss then 0 else length $ head xss
         matrix    = listArray ((1, 1), (rows, columns)) (concat xss)
 
     cases = [ ( "Example from README",


### PR DESCRIPTION
The second test case does not play well with `head` on line 21, since using `head` on an empty list yields an error.

Use `head` only when the list is not empty.