### PR TITLE
leap approaches: Present the approaches in the overview document

### DIFF
--- a/exercises/practice/leap/.approaches/introduction.md
+++ b/exercises/practice/leap/.approaches/introduction.md
@@ -1,10 +1,51 @@
 # Introduction
 
-There are various idiomatic approaches to solve Leap, such as
+There are various idiomatic approaches to solve Leap.
+All approaches listed below check for divisibility by 4, 100, and 400.
+However, they differ in the ways in which they combine these checks.
 
-- constructing [a logical expression][logical-expression],
-- using [guards][guards], and
-- using [a conditional expression][conditional-expression].
+
+## Approach: a logical expression
+
+```haskell
+isLeapYear :: Integer -> Bool
+isLeapYear year = divisibleBy 4 && (not (divisibleBy 100) || divisibleBy 400)
+  where
+    divisibleBy d = year `mod` d == 0
+```
+
+[Read more about this approach][logical-expression].
+
+
+## Approach: use guards
+
+```haskell
+isLeapYear :: Integer -> Bool
+isLeapYear year
+  | indivisibleBy 4   = False
+  | indivisibleBy 100 = True
+  | indivisibleBy 400 = False
+  | otherwise         = True
+  where
+    indivisibleBy d = year `mod` d /= 0
+```
+
+[Read more about this approach][guards].
+
+
+## Approach: a conditional expression
+
+```haskell
+isLeapYear :: Integer -> Bool
+isLeapYear year =
+  if divisibleBy 100
+    then divisibleBy 400
+    else divisibleBy 4
+  where
+    divisibleBy d = year `mod` d == 0
+```
+
+[Read more about this approach][conditional-expression].
 
 
 ## General guidance


### PR DESCRIPTION
> One thing I noticed is that the `introduction.md` document should list the approaches under their own heading and with (an excerpt of) its code.
> See https://exercism.org/tracks/csharp/exercises/collatz-conjecture/dig_deeper for an example.

_Originally posted by @ErikSchierboom in https://github.com/exercism/haskell/issues/1139#issuecomment-1430881119_

@ErikSchierboom You meant this, right?

I think this document is now compliant with the (relevant section of the) [approaches building docs](https://exercism.org/docs/building/tracks/approaches#h-approaches-overview).