### PR TITLE
Upgrade to resolver 20.11

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -45,7 +45,7 @@ in an *import statement* in the test suite, usually at the beginning:
 
 ```haskell
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import ModuleName (someFunc)
 

--- a/exercises/concept/guessing-game/stack.yaml
+++ b/exercises/concept/guessing-game/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/concept/guessing-game/stack.yaml
+++ b/exercises/concept/guessing-game/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/concept/guessing-game/stack.yaml
+++ b/exercises/concept/guessing-game/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/concept/lucians-luscious-lasagna/stack.yaml
+++ b/exercises/concept/lucians-luscious-lasagna/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/concept/lucians-luscious-lasagna/stack.yaml
+++ b/exercises/concept/lucians-luscious-lasagna/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/concept/lucians-luscious-lasagna/stack.yaml
+++ b/exercises/concept/lucians-luscious-lasagna/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/concept/pacman-rules/stack.yaml
+++ b/exercises/concept/pacman-rules/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/concept/pacman-rules/stack.yaml
+++ b/exercises/concept/pacman-rules/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/concept/pacman-rules/stack.yaml
+++ b/exercises/concept/pacman-rules/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/concept/temperature/stack.yaml
+++ b/exercises/concept/temperature/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/concept/temperature/stack.yaml
+++ b/exercises/concept/temperature/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/concept/temperature/stack.yaml
+++ b/exercises/concept/temperature/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/concept/valentines-day/stack.yaml
+++ b/exercises/concept/valentines-day/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/concept/valentines-day/stack.yaml
+++ b/exercises/concept/valentines-day/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/concept/valentines-day/stack.yaml
+++ b/exercises/concept/valentines-day/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/accumulate/stack.yaml
+++ b/exercises/practice/accumulate/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/accumulate/stack.yaml
+++ b/exercises/practice/accumulate/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/accumulate/stack.yaml
+++ b/exercises/practice/accumulate/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/accumulate/test/Tests.hs
+++ b/exercises/practice/accumulate/test/Tests.hs
@@ -1,11 +1,11 @@
 import Data.Char         (toUpper)
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Accumulate (accumulate)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/acronym/stack.yaml
+++ b/exercises/practice/acronym/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/acronym/stack.yaml
+++ b/exercises/practice/acronym/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/acronym/stack.yaml
+++ b/exercises/practice/acronym/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/acronym/test/Tests.hs
+++ b/exercises/practice/acronym/test/Tests.hs
@@ -4,12 +4,12 @@
 import Data.Foldable     (for_)
 import Data.String       (fromString)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Acronym (abbreviate)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "abbreviate" $ for_ cases test

--- a/exercises/practice/all-your-base/stack.yaml
+++ b/exercises/practice/all-your-base/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/all-your-base/stack.yaml
+++ b/exercises/practice/all-your-base/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/all-your-base/stack.yaml
+++ b/exercises/practice/all-your-base/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/all-your-base/test/Tests.hs
+++ b/exercises/practice/all-your-base/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Base (Error(..), rebase)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "rebase" $ for_ cases test

--- a/exercises/practice/allergies/stack.yaml
+++ b/exercises/practice/allergies/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/allergies/stack.yaml
+++ b/exercises/practice/allergies/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/allergies/stack.yaml
+++ b/exercises/practice/allergies/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/allergies/test/Tests.hs
+++ b/exercises/practice/allergies/test/Tests.hs
@@ -2,7 +2,7 @@
 
 import Test.QuickCheck   (Gen, forAll, forAllShrink, elements, sublistOf, suchThat)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Data.List         (delete)
 import Data.Maybe        (mapMaybe)
 
@@ -21,7 +21,7 @@ import Allergies
   )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/alphametics/stack.yaml
+++ b/exercises/practice/alphametics/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/alphametics/stack.yaml
+++ b/exercises/practice/alphametics/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/alphametics/stack.yaml
+++ b/exercises/practice/alphametics/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/alphametics/test/Tests.hs
+++ b/exercises/practice/alphametics/test/Tests.hs
@@ -4,12 +4,12 @@ import Data.Foldable     (for_)
 import Data.Function     (on)
 import Data.List         (sort)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Alphametics (solve)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "solve" $ for_ cases test

--- a/exercises/practice/anagram/stack.yaml
+++ b/exercises/practice/anagram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/anagram/stack.yaml
+++ b/exercises/practice/anagram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/anagram/stack.yaml
+++ b/exercises/practice/anagram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/anagram/test/Tests.hs
+++ b/exercises/practice/anagram/test/Tests.hs
@@ -3,12 +3,12 @@
 import Data.Foldable     (for_)
 import GHC.Exts          (fromList, toList)
 import Test.Hspec        (Spec, describe, it, shouldMatchList)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Anagram (anagramsFor)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "anagramsFor" $ for_ cases test

--- a/exercises/practice/armstrong-numbers/stack.yaml
+++ b/exercises/practice/armstrong-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/armstrong-numbers/stack.yaml
+++ b/exercises/practice/armstrong-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/armstrong-numbers/stack.yaml
+++ b/exercises/practice/armstrong-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/armstrong-numbers/test/Tests.hs
+++ b/exercises/practice/armstrong-numbers/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import ArmstrongNumbers (armstrong)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "armstrong" $ for_ cases test

--- a/exercises/practice/atbash-cipher/stack.yaml
+++ b/exercises/practice/atbash-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/atbash-cipher/stack.yaml
+++ b/exercises/practice/atbash-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/atbash-cipher/stack.yaml
+++ b/exercises/practice/atbash-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/atbash-cipher/test/Tests.hs
+++ b/exercises/practice/atbash-cipher/test/Tests.hs
@@ -2,13 +2,13 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Data.String       (fromString)
 
 import Atbash (encode, decode)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/bank-account/stack.yaml
+++ b/exercises/practice/bank-account/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/bank-account/stack.yaml
+++ b/exercises/practice/bank-account/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/bank-account/stack.yaml
+++ b/exercises/practice/bank-account/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/bank-account/test/Tests.hs
+++ b/exercises/practice/bank-account/test/Tests.hs
@@ -4,7 +4,7 @@ import Data.Foldable      (for_)
 import Data.Traversable   (for)
 import Data.Maybe         (isNothing, catMaybes)
 import Test.Hspec         (Spec, it, shouldReturn)
-import Test.Hspec.Runner  (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner  (configFailFast, defaultConfig, hspecWith)
 
 import BankAccount
   ( closeAccount
@@ -14,7 +14,7 @@ import BankAccount
   )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/beer-song/stack.yaml
+++ b/exercises/practice/beer-song/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/beer-song/stack.yaml
+++ b/exercises/practice/beer-song/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/beer-song/stack.yaml
+++ b/exercises/practice/beer-song/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/beer-song/test/Tests.hs
+++ b/exercises/practice/beer-song/test/Tests.hs
@@ -1,11 +1,11 @@
 import Control.Monad     (unless)
 import Test.Hspec        (Spec, describe, expectationFailure, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Beer (song)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 

--- a/exercises/practice/binary-search-tree/stack.yaml
+++ b/exercises/practice/binary-search-tree/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/binary-search-tree/stack.yaml
+++ b/exercises/practice/binary-search-tree/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/binary-search-tree/stack.yaml
+++ b/exercises/practice/binary-search-tree/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/binary-search-tree/test/Tests.hs
+++ b/exercises/practice/binary-search-tree/test/Tests.hs
@@ -1,5 +1,5 @@
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import BST
   ( bstLeft
@@ -13,7 +13,7 @@ import BST
   )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/binary-search/stack.yaml
+++ b/exercises/practice/binary-search/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/binary-search/stack.yaml
+++ b/exercises/practice/binary-search/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/binary-search/stack.yaml
+++ b/exercises/practice/binary-search/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/binary-search/test/Tests.hs
+++ b/exercises/practice/binary-search/test/Tests.hs
@@ -3,12 +3,12 @@
 import Data.Array        (Array, listArray)
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import BinarySearch      (find)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "find" $ for_ bases $ for_ cases . test

--- a/exercises/practice/binary/stack.yaml
+++ b/exercises/practice/binary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/binary/stack.yaml
+++ b/exercises/practice/binary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/binary/stack.yaml
+++ b/exercises/practice/binary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/binary/test/Tests.hs
+++ b/exercises/practice/binary/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Binary (toDecimal)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "toDecimal" $ for_ cases test

--- a/exercises/practice/bob/stack.yaml
+++ b/exercises/practice/bob/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/bob/stack.yaml
+++ b/exercises/practice/bob/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/bob/stack.yaml
+++ b/exercises/practice/bob/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/bob/test/Tests.hs
+++ b/exercises/practice/bob/test/Tests.hs
@@ -3,13 +3,13 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Data.String       (fromString)
 
 import Bob (responseFor)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "responseFor" $ for_ cases test

--- a/exercises/practice/bowling/stack.yaml
+++ b/exercises/practice/bowling/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/bowling/stack.yaml
+++ b/exercises/practice/bowling/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/bowling/stack.yaml
+++ b/exercises/practice/bowling/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/bowling/test/Tests.hs
+++ b/exercises/practice/bowling/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Bowling (score, BowlingError(..))
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "roll, score" $ for_ cases test

--- a/exercises/practice/change/stack.yaml
+++ b/exercises/practice/change/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/change/stack.yaml
+++ b/exercises/practice/change/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/change/stack.yaml
+++ b/exercises/practice/change/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/change/test/Tests.hs
+++ b/exercises/practice/change/test/Tests.hs
@@ -3,12 +3,12 @@
 import Data.Foldable     (for_)
 import Data.List         (sort)
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Change (findFewestCoins)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = for_ cases test

--- a/exercises/practice/clock/stack.yaml
+++ b/exercises/practice/clock/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/clock/stack.yaml
+++ b/exercises/practice/clock/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/clock/stack.yaml
+++ b/exercises/practice/clock/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/clock/test/Tests.hs
+++ b/exercises/practice/clock/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Clock (addDelta, fromHourMin, toString)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/collatz-conjecture/stack.yaml
+++ b/exercises/practice/collatz-conjecture/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/collatz-conjecture/stack.yaml
+++ b/exercises/practice/collatz-conjecture/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/collatz-conjecture/stack.yaml
+++ b/exercises/practice/collatz-conjecture/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/collatz-conjecture/test/Tests.hs
+++ b/exercises/practice/collatz-conjecture/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import CollatzConjecture (collatz)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "collatz" $ for_ cases test

--- a/exercises/practice/complex-numbers/stack.yaml
+++ b/exercises/practice/complex-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/complex-numbers/stack.yaml
+++ b/exercises/practice/complex-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/complex-numbers/stack.yaml
+++ b/exercises/practice/complex-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/complex-numbers/test/Tests.hs
+++ b/exercises/practice/complex-numbers/test/Tests.hs
@@ -5,7 +5,7 @@ import qualified Prelude as P
 import Data.Function     (on)
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import ComplexNumbers
   ( Complex
@@ -22,7 +22,7 @@ import ComplexNumbers
   )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/connect/stack.yaml
+++ b/exercises/practice/connect/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/connect/stack.yaml
+++ b/exercises/practice/connect/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/connect/stack.yaml
+++ b/exercises/practice/connect/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/connect/test/Tests.hs
+++ b/exercises/practice/connect/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Connect (Mark(Cross,Nought), winner)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "winner" $ for_ cases test

--- a/exercises/practice/crypto-square/stack.yaml
+++ b/exercises/practice/crypto-square/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/crypto-square/stack.yaml
+++ b/exercises/practice/crypto-square/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/crypto-square/stack.yaml
+++ b/exercises/practice/crypto-square/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/crypto-square/test/Tests.hs
+++ b/exercises/practice/crypto-square/test/Tests.hs
@@ -4,12 +4,12 @@ import Data.Char         (isSpace)
 import Data.Foldable     (for_)
 import Data.Function     (on)
 import Test.Hspec        (Spec, describe, it, shouldBe, shouldMatchList)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import CryptoSquare (encode)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "encode" $ for_ cases test

--- a/exercises/practice/custom-set/stack.yaml
+++ b/exercises/practice/custom-set/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/custom-set/stack.yaml
+++ b/exercises/practice/custom-set/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/custom-set/stack.yaml
+++ b/exercises/practice/custom-set/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/custom-set/test/Tests.hs
+++ b/exercises/practice/custom-set/test/Tests.hs
@@ -2,7 +2,7 @@
 
 import Data.List         (sort)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Prelude hiding (null)
 
@@ -22,7 +22,7 @@ import CustomSet
   )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/diamond/stack.yaml
+++ b/exercises/practice/diamond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/diamond/stack.yaml
+++ b/exercises/practice/diamond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/diamond/stack.yaml
+++ b/exercises/practice/diamond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/diamond/test/Tests.hs
+++ b/exercises/practice/diamond/test/Tests.hs
@@ -8,7 +8,7 @@ import Data.List               (isSuffixOf)
 import Data.Maybe              (isJust, isNothing)
 import Data.String.Conversions (convertString)
 import Test.Hspec              (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner       (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner       (configFailFast, defaultConfig, hspecWith)
 import Test.QuickCheck         (arbitraryASCIIChar, conjoin, counterexample,
                                 discard, elements, forAll, forAllShrink, Gen,
                                 Property, suchThat, Testable, (===))
@@ -16,7 +16,7 @@ import Test.QuickCheck         (arbitraryASCIIChar, conjoin, counterexample,
 import Diamond (diamond)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "diamond" $ do

--- a/exercises/practice/difference-of-squares/stack.yaml
+++ b/exercises/practice/difference-of-squares/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/difference-of-squares/stack.yaml
+++ b/exercises/practice/difference-of-squares/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/difference-of-squares/stack.yaml
+++ b/exercises/practice/difference-of-squares/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/difference-of-squares/test/Tests.hs
+++ b/exercises/practice/difference-of-squares/test/Tests.hs
@@ -1,12 +1,12 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Squares (difference, squareOfSum, sumOfSquares)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/dnd-character/stack.yaml
+++ b/exercises/practice/dnd-character/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/dnd-character/stack.yaml
+++ b/exercises/practice/dnd-character/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/dnd-character/stack.yaml
+++ b/exercises/practice/dnd-character/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/dnd-character/test/Tests.hs
+++ b/exercises/practice/dnd-character/test/Tests.hs
@@ -3,7 +3,7 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Test.QuickCheck
 import Text.Printf       (printf)
 
@@ -16,7 +16,7 @@ data Case = Case { input    :: Int
 type Ability = Character -> Int
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/dominoes/stack.yaml
+++ b/exercises/practice/dominoes/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/dominoes/stack.yaml
+++ b/exercises/practice/dominoes/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/dominoes/stack.yaml
+++ b/exercises/practice/dominoes/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/dominoes/test/Tests.hs
+++ b/exercises/practice/dominoes/test/Tests.hs
@@ -5,13 +5,13 @@ import Control.Monad     (forM_, unless)
 import Data.Foldable     (for_)
 import Data.Function     (on)
 import Test.Hspec        (Spec, describe, expectationFailure, it, shouldBe, shouldMatchList)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Text.Printf       (printf)
 
 import Dominoes (chain)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "chain" $ for_ cases test

--- a/exercises/practice/etl/stack.yaml
+++ b/exercises/practice/etl/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/etl/stack.yaml
+++ b/exercises/practice/etl/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/etl/stack.yaml
+++ b/exercises/practice/etl/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/etl/test/Tests.hs
+++ b/exercises/practice/etl/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Map          (fromList)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import ETL (transform)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs =

--- a/exercises/practice/food-chain/.meta/examples/success-standard/src/FoodChain.hs
+++ b/exercises/practice/food-chain/.meta/examples/success-standard/src/FoodChain.hs
@@ -11,9 +11,7 @@ data Animal = Fly | Spider | Bird | Cat | Dog | Goat | Cow | Horse
 -- animals. E.g. animalNames ! Fly == "fly"
 animalNames :: Array Animal String
 animalNames = listArray (Fly, Horse) $ map showLower [Fly ..]
-  where showLower a = let (h:t) = show a
-                      in (toLower h : t)
-
+  where showLower = map toLower . show
 song :: String
 song = init . unlines $ map verse [Fly ..]
 

--- a/exercises/practice/food-chain/stack.yaml
+++ b/exercises/practice/food-chain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/food-chain/stack.yaml
+++ b/exercises/practice/food-chain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/food-chain/stack.yaml
+++ b/exercises/practice/food-chain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/food-chain/test/Tests.hs
+++ b/exercises/practice/food-chain/test/Tests.hs
@@ -1,11 +1,11 @@
 import Control.Monad     (unless)
 import Test.Hspec        (Spec, describe, expectationFailure, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import FoodChain (song)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "song" $ do

--- a/exercises/practice/forth/stack.yaml
+++ b/exercises/practice/forth/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/forth/stack.yaml
+++ b/exercises/practice/forth/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/forth/stack.yaml
+++ b/exercises/practice/forth/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/forth/test/Tests.hs
+++ b/exercises/practice/forth/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Control.Monad     (foldM)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Forth (ForthError(..), emptyState, evalText, toList)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/gigasecond/stack.yaml
+++ b/exercises/practice/gigasecond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/gigasecond/stack.yaml
+++ b/exercises/practice/gigasecond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/gigasecond/stack.yaml
+++ b/exercises/practice/gigasecond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/gigasecond/test/Tests.hs
+++ b/exercises/practice/gigasecond/test/Tests.hs
@@ -4,16 +4,8 @@ import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Gigasecond (fromDay)
 
-import Data.Time.Format
-  ( ParseTime
-  , TimeLocale
-  , defaultTimeLocale
-  , iso8601DateFormat
-  , parseTimeOrError
-  )
-
-readTime :: ParseTime t => TimeLocale -> String -> String -> t
-readTime = parseTimeOrError True
+import Data.Maybe (fromJust)
+import Data.Time.Format.ISO8601 (iso8601ParseM)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFailFast = True} specs
@@ -21,8 +13,7 @@ main = hspecWith defaultConfig {configFailFast = True} specs
 specs :: Spec
 specs = describe "fromDay" $ do
 
-          let dt = readTime defaultTimeLocale
-                   (iso8601DateFormat (Just "%T%Z")) :: String -> UTCTime
+          let dt = fromJust . iso8601ParseM :: String -> UTCTime
 
           it "from apr 25 2011" $
             fromDay (dt "2011-04-25T00:00:00Z")

--- a/exercises/practice/gigasecond/test/Tests.hs
+++ b/exercises/practice/gigasecond/test/Tests.hs
@@ -1,6 +1,6 @@
 import Data.Time.Clock   (UTCTime)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Gigasecond (fromDay)
 
@@ -16,7 +16,7 @@ readTime :: ParseTime t => TimeLocale -> String -> String -> t
 readTime = parseTimeOrError True
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "fromDay" $ do

--- a/exercises/practice/go-counting/stack.yaml
+++ b/exercises/practice/go-counting/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/go-counting/stack.yaml
+++ b/exercises/practice/go-counting/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/go-counting/stack.yaml
+++ b/exercises/practice/go-counting/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/go-counting/test/Tests.hs
+++ b/exercises/practice/go-counting/test/Tests.hs
@@ -3,14 +3,14 @@ import Data.List         (foldl')
 import Data.Set          (toAscList)
 import Data.Tuple        (swap)
 import Test.Hspec        (Spec, it, shouldBe, shouldMatchList)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import qualified Data.Map as Map
 
 import Counting (Color(Black,White), territories, territoryFor)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/grade-school/stack.yaml
+++ b/exercises/practice/grade-school/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/grade-school/stack.yaml
+++ b/exercises/practice/grade-school/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/grade-school/stack.yaml
+++ b/exercises/practice/grade-school/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/grade-school/test/Tests.hs
+++ b/exercises/practice/grade-school/test/Tests.hs
@@ -2,12 +2,12 @@
 {-# LANGUAGE TupleSections #-}
 
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import School (add, empty, grade, sorted)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/grains/stack.yaml
+++ b/exercises/practice/grains/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/grains/stack.yaml
+++ b/exercises/practice/grains/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/grains/stack.yaml
+++ b/exercises/practice/grains/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/grains/test/Tests.hs
+++ b/exercises/practice/grains/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Grains (square, total)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/hamming/stack.yaml
+++ b/exercises/practice/hamming/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/hamming/stack.yaml
+++ b/exercises/practice/hamming/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/hamming/stack.yaml
+++ b/exercises/practice/hamming/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/hamming/test/Tests.hs
+++ b/exercises/practice/hamming/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Hamming (distance)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "distance" $ for_ cases test

--- a/exercises/practice/hello-world/stack.yaml
+++ b/exercises/practice/hello-world/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/hello-world/stack.yaml
+++ b/exercises/practice/hello-world/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/hello-world/stack.yaml
+++ b/exercises/practice/hello-world/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/hello-world/test/Tests.hs
+++ b/exercises/practice/hello-world/test/Tests.hs
@@ -1,10 +1,10 @@
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import HelloWorld (hello)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = it "hello" $

--- a/exercises/practice/hexadecimal/stack.yaml
+++ b/exercises/practice/hexadecimal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/hexadecimal/stack.yaml
+++ b/exercises/practice/hexadecimal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/hexadecimal/stack.yaml
+++ b/exercises/practice/hexadecimal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/hexadecimal/test/Tests.hs
+++ b/exercises/practice/hexadecimal/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Hexadecimal (hexToInt)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "hexToInt" $ for_ cases test

--- a/exercises/practice/house/stack.yaml
+++ b/exercises/practice/house/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/house/stack.yaml
+++ b/exercises/practice/house/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/house/stack.yaml
+++ b/exercises/practice/house/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/house/test/Tests.hs
+++ b/exercises/practice/house/test/Tests.hs
@@ -1,11 +1,11 @@
 import Control.Monad     (unless)
 import Test.Hspec        (Spec, describe, expectationFailure, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import House (rhyme)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "rhyme" $ do

--- a/exercises/practice/isbn-verifier/stack.yaml
+++ b/exercises/practice/isbn-verifier/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/isbn-verifier/stack.yaml
+++ b/exercises/practice/isbn-verifier/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/isbn-verifier/stack.yaml
+++ b/exercises/practice/isbn-verifier/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/isbn-verifier/test/Tests.hs
+++ b/exercises/practice/isbn-verifier/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import IsbnVerifier (isbn)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "isbn" $ for_ cases test

--- a/exercises/practice/isogram/stack.yaml
+++ b/exercises/practice/isogram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/isogram/stack.yaml
+++ b/exercises/practice/isogram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/isogram/stack.yaml
+++ b/exercises/practice/isogram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/isogram/test/Tests.hs
+++ b/exercises/practice/isogram/test/Tests.hs
@@ -4,12 +4,12 @@
 import Data.Foldable     (for_)
 import Data.String       (fromString)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Isogram (isIsogram)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "isIsogram" $ for_ cases test

--- a/exercises/practice/kindergarten-garden/stack.yaml
+++ b/exercises/practice/kindergarten-garden/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/kindergarten-garden/stack.yaml
+++ b/exercises/practice/kindergarten-garden/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/kindergarten-garden/stack.yaml
+++ b/exercises/practice/kindergarten-garden/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/kindergarten-garden/test/Tests.hs
+++ b/exercises/practice/kindergarten-garden/test/Tests.hs
@@ -1,5 +1,5 @@
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Garden
   ( Plant ( Clover
@@ -12,7 +12,7 @@ import Garden
   )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 defaultStudents :: [String]
 defaultStudents =

--- a/exercises/practice/largest-series-product/stack.yaml
+++ b/exercises/practice/largest-series-product/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/largest-series-product/stack.yaml
+++ b/exercises/practice/largest-series-product/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/largest-series-product/stack.yaml
+++ b/exercises/practice/largest-series-product/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/largest-series-product/test/Tests.hs
+++ b/exercises/practice/largest-series-product/test/Tests.hs
@@ -1,12 +1,12 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Series (Error(..), largestProduct)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "largestProduct" $ do

--- a/exercises/practice/leap/stack.yaml
+++ b/exercises/practice/leap/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/leap/stack.yaml
+++ b/exercises/practice/leap/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/leap/stack.yaml
+++ b/exercises/practice/leap/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/leap/test/Tests.hs
+++ b/exercises/practice/leap/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import LeapYear (isLeapYear)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "isLeapYear" $ for_ cases test

--- a/exercises/practice/lens-person/stack.yaml
+++ b/exercises/practice/lens-person/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/lens-person/stack.yaml
+++ b/exercises/practice/lens-person/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/lens-person/stack.yaml
+++ b/exercises/practice/lens-person/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/lens-person/test/Tests.hs
+++ b/exercises/practice/lens-person/test/Tests.hs
@@ -1,7 +1,7 @@
 import Data.Char          (toUpper)
 import Data.Time.Calendar (fromGregorian)
 import Test.Hspec         (Spec, it, shouldBe)
-import Test.Hspec.Runner  (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner  (configFailFast, defaultConfig, hspecWith)
 
 import Person
   ( Address (..)
@@ -15,7 +15,7 @@ import Person
   )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/linked-list/stack.yaml
+++ b/exercises/practice/linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/linked-list/stack.yaml
+++ b/exercises/practice/linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/linked-list/stack.yaml
+++ b/exercises/practice/linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/linked-list/test/Tests.hs
+++ b/exercises/practice/linked-list/test/Tests.hs
@@ -1,10 +1,10 @@
 import Test.Hspec        (Spec, it, shouldReturn)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Deque (mkDeque, pop, push, shift, unshift)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 {-# ANN module "HLint: ignore Reduce duplication" #-}
 specs :: Spec

--- a/exercises/practice/list-ops/stack.yaml
+++ b/exercises/practice/list-ops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/list-ops/stack.yaml
+++ b/exercises/practice/list-ops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/list-ops/stack.yaml
+++ b/exercises/practice/list-ops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/list-ops/test/Tests.hs
+++ b/exercises/practice/list-ops/test/Tests.hs
@@ -2,7 +2,7 @@
 
 import Control.Exception (Exception, throw, evaluate)
 import Test.Hspec        (Spec, describe, it, shouldBe, shouldThrow)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Prelude hiding
     ( (++)
@@ -28,7 +28,7 @@ import ListOps
 data StrictException = StrictException deriving (Eq, Show, Exception)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/luhn/stack.yaml
+++ b/exercises/practice/luhn/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/luhn/stack.yaml
+++ b/exercises/practice/luhn/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/luhn/stack.yaml
+++ b/exercises/practice/luhn/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/luhn/test/Tests.hs
+++ b/exercises/practice/luhn/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Luhn (isValid)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "valid" $ for_ cases test

--- a/exercises/practice/matching-brackets/stack.yaml
+++ b/exercises/practice/matching-brackets/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/matching-brackets/stack.yaml
+++ b/exercises/practice/matching-brackets/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/matching-brackets/stack.yaml
+++ b/exercises/practice/matching-brackets/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/matching-brackets/test/Tests.hs
+++ b/exercises/practice/matching-brackets/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Brackets (arePaired)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "arePaired" $ for_ cases test

--- a/exercises/practice/matrix/stack.yaml
+++ b/exercises/practice/matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/matrix/stack.yaml
+++ b/exercises/practice/matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/matrix/stack.yaml
+++ b/exercises/practice/matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/matrix/test/Tests.hs
+++ b/exercises/practice/matrix/test/Tests.hs
@@ -1,6 +1,6 @@
 import Control.Arrow     ((&&&))
 import Test.Hspec        (Spec, it, shouldBe, shouldNotBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Test.QuickCheck   (Gen, choose, elements, forAllShow, listOf1, vector)
 
 import qualified Data.Vector as Vector (fromList)
@@ -20,7 +20,7 @@ import Matrix
   )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/meetup/stack.yaml
+++ b/exercises/practice/meetup/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/meetup/stack.yaml
+++ b/exercises/practice/meetup/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/meetup/stack.yaml
+++ b/exercises/practice/meetup/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/meetup/test/Tests.hs
+++ b/exercises/practice/meetup/test/Tests.hs
@@ -3,12 +3,12 @@
 import Data.Foldable      (for_)
 import Data.Time.Calendar (fromGregorian)
 import Test.Hspec         (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner  (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner  (configFailFast, defaultConfig, hspecWith)
 
 import Meetup (Weekday(..), Schedule(..), meetupDay)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "meetupDay" $ for_ cases test

--- a/exercises/practice/minesweeper/stack.yaml
+++ b/exercises/practice/minesweeper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/minesweeper/stack.yaml
+++ b/exercises/practice/minesweeper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/minesweeper/stack.yaml
+++ b/exercises/practice/minesweeper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/minesweeper/test/Tests.hs
+++ b/exercises/practice/minesweeper/test/Tests.hs
@@ -1,11 +1,11 @@
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Minesweeper (annotate)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "annotate" $ for_ cases test

--- a/exercises/practice/nth-prime/stack.yaml
+++ b/exercises/practice/nth-prime/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/nth-prime/stack.yaml
+++ b/exercises/practice/nth-prime/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/nth-prime/stack.yaml
+++ b/exercises/practice/nth-prime/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/nth-prime/test/Tests.hs
+++ b/exercises/practice/nth-prime/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Prime (nth)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "nth" $ for_ cases test

--- a/exercises/practice/nucleotide-count/stack.yaml
+++ b/exercises/practice/nucleotide-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/nucleotide-count/stack.yaml
+++ b/exercises/practice/nucleotide-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/nucleotide-count/stack.yaml
+++ b/exercises/practice/nucleotide-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/nucleotide-count/test/Tests.hs
+++ b/exercises/practice/nucleotide-count/test/Tests.hs
@@ -4,12 +4,12 @@
 import Data.Either       (isLeft)
 import Data.Map          (findWithDefault)
 import Test.Hspec        (Spec, describe, it, shouldSatisfy)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import DNA (nucleotideCounts, Nucleotide(..))
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/ocr-numbers/stack.yaml
+++ b/exercises/practice/ocr-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/ocr-numbers/stack.yaml
+++ b/exercises/practice/ocr-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/ocr-numbers/stack.yaml
+++ b/exercises/practice/ocr-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/ocr-numbers/test/Tests.hs
+++ b/exercises/practice/ocr-numbers/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import OCR (convert)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "convert" $ for_ cases test

--- a/exercises/practice/octal/stack.yaml
+++ b/exercises/practice/octal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/octal/stack.yaml
+++ b/exercises/practice/octal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/octal/stack.yaml
+++ b/exercises/practice/octal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/octal/test/Tests.hs
+++ b/exercises/practice/octal/test/Tests.hs
@@ -1,5 +1,5 @@
 import Test.Hspec        (Spec, it)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Test.QuickCheck   (Positive(Positive), property)
 
 import qualified Numeric as Num (showOct)
@@ -7,7 +7,7 @@ import qualified Numeric as Num (showOct)
 import Octal (readOct, showOct)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/palindrome-products/.meta/examples/success-standard/src/Palindromes.hs
+++ b/exercises/practice/palindrome-products/.meta/examples/success-standard/src/Palindromes.hs
@@ -5,9 +5,9 @@ type Comparator a = a -> a -> Ordering
 type Product2 a = (a, [(a, a)])
 
 isPalindrome :: Integral a => a -> Bool
-isPalindrome x = x < base || lastDigit /= 0 && digits == reverse digits
+isPalindrome x = x < base || head digits /= 0 && digits == reverse digits
   where base = 10
-        digits@(lastDigit:_) = revDigitsBase base x
+        digits = revDigitsBase base x
 
 revDigitsBase :: Integral a => a -> a -> [a]
 revDigitsBase base = go

--- a/exercises/practice/palindrome-products/stack.yaml
+++ b/exercises/practice/palindrome-products/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/palindrome-products/stack.yaml
+++ b/exercises/practice/palindrome-products/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/palindrome-products/stack.yaml
+++ b/exercises/practice/palindrome-products/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/palindrome-products/test/Tests.hs
+++ b/exercises/practice/palindrome-products/test/Tests.hs
@@ -3,12 +3,12 @@
 import Data.Foldable     (for_)
 import Data.List         (nub, sort)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Palindromes (largestPalindrome, smallestPalindrome)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = for_ cases test

--- a/exercises/practice/pangram/stack.yaml
+++ b/exercises/practice/pangram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/pangram/stack.yaml
+++ b/exercises/practice/pangram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/pangram/stack.yaml
+++ b/exercises/practice/pangram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/pangram/test/Tests.hs
+++ b/exercises/practice/pangram/test/Tests.hs
@@ -4,12 +4,12 @@
 import Data.Foldable     (for_)
 import Data.String       (fromString)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Pangram (isPangram)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "isPangram" $ for_ cases test

--- a/exercises/practice/parallel-letter-frequency/stack.yaml
+++ b/exercises/practice/parallel-letter-frequency/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/parallel-letter-frequency/stack.yaml
+++ b/exercises/practice/parallel-letter-frequency/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/parallel-letter-frequency/stack.yaml
+++ b/exercises/practice/parallel-letter-frequency/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/parallel-letter-frequency/test/Tests.hs
+++ b/exercises/practice/parallel-letter-frequency/test/Tests.hs
@@ -3,13 +3,13 @@
 import Data.Map          (empty, fromList, lookup, singleton)
 import Data.Text         (concat)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Prelude    hiding (concat, lookup)
 
 import Frequency (frequency)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/pascals-triangle/stack.yaml
+++ b/exercises/practice/pascals-triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/pascals-triangle/stack.yaml
+++ b/exercises/practice/pascals-triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/pascals-triangle/stack.yaml
+++ b/exercises/practice/pascals-triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/pascals-triangle/test/Tests.hs
+++ b/exercises/practice/pascals-triangle/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Triangle (rows)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "rows" $ for_ rowsCases rowsTest

--- a/exercises/practice/perfect-numbers/stack.yaml
+++ b/exercises/practice/perfect-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/perfect-numbers/stack.yaml
+++ b/exercises/practice/perfect-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/perfect-numbers/stack.yaml
+++ b/exercises/practice/perfect-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/perfect-numbers/test/Tests.hs
+++ b/exercises/practice/perfect-numbers/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import PerfectNumbers (Classification(Deficient, Perfect, Abundant), classify)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "classify" $ for_ cases test

--- a/exercises/practice/phone-number/stack.yaml
+++ b/exercises/practice/phone-number/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/phone-number/stack.yaml
+++ b/exercises/practice/phone-number/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/phone-number/stack.yaml
+++ b/exercises/practice/phone-number/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/phone-number/test/Tests.hs
+++ b/exercises/practice/phone-number/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Phone (number)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "number" $ for_ cases test

--- a/exercises/practice/pig-latin/stack.yaml
+++ b/exercises/practice/pig-latin/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/pig-latin/stack.yaml
+++ b/exercises/practice/pig-latin/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/pig-latin/stack.yaml
+++ b/exercises/practice/pig-latin/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/pig-latin/test/Tests.hs
+++ b/exercises/practice/pig-latin/test/Tests.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import PigLatin (translate)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "translate" $ do

--- a/exercises/practice/poker/stack.yaml
+++ b/exercises/practice/poker/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/poker/stack.yaml
+++ b/exercises/practice/poker/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/poker/stack.yaml
+++ b/exercises/practice/poker/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/poker/test/Tests.hs
+++ b/exercises/practice/poker/test/Tests.hs
@@ -3,12 +3,12 @@
 import Data.Foldable     (for_)
 import Data.List         (sort)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Poker (bestHands)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "bestHands" $ for_ cases test

--- a/exercises/practice/pov/stack.yaml
+++ b/exercises/practice/pov/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/pov/stack.yaml
+++ b/exercises/practice/pov/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/pov/stack.yaml
+++ b/exercises/practice/pov/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/pov/test/Tests.hs
+++ b/exercises/practice/pov/test/Tests.hs
@@ -5,12 +5,12 @@ import Data.Function     (on)
 import Data.Tree         (Tree(Node), rootLabel)
 import Data.List         (sort)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import POV (fromPOV, tracePathBetween)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/prime-factors/stack.yaml
+++ b/exercises/practice/prime-factors/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/prime-factors/stack.yaml
+++ b/exercises/practice/prime-factors/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/prime-factors/stack.yaml
+++ b/exercises/practice/prime-factors/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/prime-factors/test/Tests.hs
+++ b/exercises/practice/prime-factors/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import PrimeFactors (primeFactors)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "primeFactors" $ for_ cases test

--- a/exercises/practice/protein-translation/stack.yaml
+++ b/exercises/practice/protein-translation/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/protein-translation/stack.yaml
+++ b/exercises/practice/protein-translation/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/protein-translation/stack.yaml
+++ b/exercises/practice/protein-translation/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/protein-translation/test/Tests.hs
+++ b/exercises/practice/protein-translation/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import ProteinTranslation (proteins)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "proteins" $ for_ cases test

--- a/exercises/practice/proverb/stack.yaml
+++ b/exercises/practice/proverb/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/proverb/stack.yaml
+++ b/exercises/practice/proverb/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/proverb/stack.yaml
+++ b/exercises/practice/proverb/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/proverb/test/Tests.hs
+++ b/exercises/practice/proverb/test/Tests.hs
@@ -2,13 +2,13 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Data.List (intercalate)
 
 import Proverb (recite)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "recite" $ for_ cases test

--- a/exercises/practice/pythagorean-triplet/stack.yaml
+++ b/exercises/practice/pythagorean-triplet/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/pythagorean-triplet/stack.yaml
+++ b/exercises/practice/pythagorean-triplet/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/pythagorean-triplet/stack.yaml
+++ b/exercises/practice/pythagorean-triplet/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/pythagorean-triplet/test/Tests.hs
+++ b/exercises/practice/pythagorean-triplet/test/Tests.hs
@@ -3,12 +3,12 @@
 import Data.Foldable     (for_)
 import Data.List         (sort)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Triplet (tripletsWithSum)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "pythagoreanTriplets" $ for_ cases test

--- a/exercises/practice/queen-attack/stack.yaml
+++ b/exercises/practice/queen-attack/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/queen-attack/stack.yaml
+++ b/exercises/practice/queen-attack/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/queen-attack/stack.yaml
+++ b/exercises/practice/queen-attack/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/queen-attack/test/Tests.hs
+++ b/exercises/practice/queen-attack/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Queens (boardString, canAttack)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/rail-fence-cipher/stack.yaml
+++ b/exercises/practice/rail-fence-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/rail-fence-cipher/stack.yaml
+++ b/exercises/practice/rail-fence-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/rail-fence-cipher/stack.yaml
+++ b/exercises/practice/rail-fence-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/rail-fence-cipher/test/Tests.hs
+++ b/exercises/practice/rail-fence-cipher/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import RailFenceCipher (encode, decode)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/raindrops/stack.yaml
+++ b/exercises/practice/raindrops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/raindrops/stack.yaml
+++ b/exercises/practice/raindrops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/raindrops/stack.yaml
+++ b/exercises/practice/raindrops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/raindrops/test/Tests.hs
+++ b/exercises/practice/raindrops/test/Tests.hs
@@ -3,13 +3,13 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Data.String       (fromString)
 
 import Raindrops (convert)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "convert" $ for_ cases test

--- a/exercises/practice/resistor-color-duo/stack.yaml
+++ b/exercises/practice/resistor-color-duo/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/resistor-color-duo/stack.yaml
+++ b/exercises/practice/resistor-color-duo/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/resistor-color-duo/stack.yaml
+++ b/exercises/practice/resistor-color-duo/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/resistor-color-duo/test/Tests.hs
+++ b/exercises/practice/resistor-color-duo/test/Tests.hs
@@ -3,13 +3,13 @@
 
 import Data.Foldable              (for_)
 import Test.Hspec                 (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner          (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner          (configFailFast, defaultConfig, hspecWith)
 import Test.QuickCheck            (Gen, elements, forAll)
 
 import ResistorColors (Color (..), value)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "value" $ do

--- a/exercises/practice/resistor-color-trio/stack.yaml
+++ b/exercises/practice/resistor-color-trio/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/resistor-color-trio/stack.yaml
+++ b/exercises/practice/resistor-color-trio/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/resistor-color-trio/stack.yaml
+++ b/exercises/practice/resistor-color-trio/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/resistor-color-trio/test/Tests.hs
+++ b/exercises/practice/resistor-color-trio/test/Tests.hs
@@ -4,13 +4,13 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Data.String       (fromString)
 
 import ResistorColors (Color(..), Resistor(..), label, ohms)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/rna-transcription/stack.yaml
+++ b/exercises/practice/rna-transcription/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/rna-transcription/stack.yaml
+++ b/exercises/practice/rna-transcription/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/rna-transcription/stack.yaml
+++ b/exercises/practice/rna-transcription/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/rna-transcription/test/Tests.hs
+++ b/exercises/practice/rna-transcription/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import DNA (toRNA)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "toRNA" $ for_ cases test

--- a/exercises/practice/robot-name/stack.yaml
+++ b/exercises/practice/robot-name/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/robot-name/stack.yaml
+++ b/exercises/practice/robot-name/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/robot-name/stack.yaml
+++ b/exercises/practice/robot-name/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/robot-name/test/Tests.hs
+++ b/exercises/practice/robot-name/test/Tests.hs
@@ -6,12 +6,12 @@ import Control.Monad.Trans (lift)
 import Data.Ix             (inRange)
 import Data.List           (group, intercalate, sort)
 import Test.Hspec          (Spec, expectationFailure, it, shouldBe, shouldNotBe, shouldSatisfy)
-import Test.Hspec.Runner   (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner   (configFailFast, defaultConfig, hspecWith)
 
 import Robot (initialState, mkRobot, resetName, robotName)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/robot-simulator/stack.yaml
+++ b/exercises/practice/robot-simulator/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/robot-simulator/stack.yaml
+++ b/exercises/practice/robot-simulator/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/robot-simulator/stack.yaml
+++ b/exercises/practice/robot-simulator/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/robot-simulator/test/Tests.hs
+++ b/exercises/practice/robot-simulator/test/Tests.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Robot
   ( Bearing ( East
@@ -16,7 +16,7 @@ import Robot
   )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/roman-numerals/stack.yaml
+++ b/exercises/practice/roman-numerals/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/roman-numerals/stack.yaml
+++ b/exercises/practice/roman-numerals/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/roman-numerals/stack.yaml
+++ b/exercises/practice/roman-numerals/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/roman-numerals/test/Tests.hs
+++ b/exercises/practice/roman-numerals/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Roman (numerals)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "numerals" $ for_ cases test

--- a/exercises/practice/rotational-cipher/stack.yaml
+++ b/exercises/practice/rotational-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/rotational-cipher/stack.yaml
+++ b/exercises/practice/rotational-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/rotational-cipher/stack.yaml
+++ b/exercises/practice/rotational-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/rotational-cipher/test/Tests.hs
+++ b/exercises/practice/rotational-cipher/test/Tests.hs
@@ -2,13 +2,13 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Data.String       (fromString)
 
 import RotationalCipher (rotate)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "rotate" $ for_ cases test

--- a/exercises/practice/run-length-encoding/stack.yaml
+++ b/exercises/practice/run-length-encoding/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/run-length-encoding/stack.yaml
+++ b/exercises/practice/run-length-encoding/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/run-length-encoding/stack.yaml
+++ b/exercises/practice/run-length-encoding/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/run-length-encoding/test/Tests.hs
+++ b/exercises/practice/run-length-encoding/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import RunLength (encode, decode)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/saddle-points/stack.yaml
+++ b/exercises/practice/saddle-points/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/saddle-points/stack.yaml
+++ b/exercises/practice/saddle-points/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/saddle-points/stack.yaml
+++ b/exercises/practice/saddle-points/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/saddle-points/test/Tests.hs
+++ b/exercises/practice/saddle-points/test/Tests.hs
@@ -3,12 +3,12 @@
 import Data.Array        (listArray)
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Matrix (saddlePoints)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "saddlePoints" $ for_ cases test

--- a/exercises/practice/say/stack.yaml
+++ b/exercises/practice/say/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/say/stack.yaml
+++ b/exercises/practice/say/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/say/stack.yaml
+++ b/exercises/practice/say/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/say/test/Tests.hs
+++ b/exercises/practice/say/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Say (inEnglish)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "inEnglish" $ for_ cases test

--- a/exercises/practice/scrabble-score/stack.yaml
+++ b/exercises/practice/scrabble-score/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/scrabble-score/stack.yaml
+++ b/exercises/practice/scrabble-score/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/scrabble-score/stack.yaml
+++ b/exercises/practice/scrabble-score/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/scrabble-score/test/Tests.hs
+++ b/exercises/practice/scrabble-score/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Scrabble (scoreLetter, scoreWord)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/secret-handshake/stack.yaml
+++ b/exercises/practice/secret-handshake/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/secret-handshake/stack.yaml
+++ b/exercises/practice/secret-handshake/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/secret-handshake/stack.yaml
+++ b/exercises/practice/secret-handshake/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/secret-handshake/test/Tests.hs
+++ b/exercises/practice/secret-handshake/test/Tests.hs
@@ -1,10 +1,10 @@
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import SecretHandshake (handshake)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/series/stack.yaml
+++ b/exercises/practice/series/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/series/stack.yaml
+++ b/exercises/practice/series/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/series/stack.yaml
+++ b/exercises/practice/series/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/series/test/Tests.hs
+++ b/exercises/practice/series/test/Tests.hs
@@ -4,12 +4,12 @@
 
 import GHC.Exts          (toList)
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Series (slices)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/sgf-parsing/stack.yaml
+++ b/exercises/practice/sgf-parsing/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/sgf-parsing/stack.yaml
+++ b/exercises/practice/sgf-parsing/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/sgf-parsing/stack.yaml
+++ b/exercises/practice/sgf-parsing/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/sgf-parsing/test/Tests.hs
+++ b/exercises/practice/sgf-parsing/test/Tests.hs
@@ -4,12 +4,12 @@ import Data.Foldable     (for_)
 import Data.Map          (fromList)
 import Data.Tree         (Tree(Node))
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Sgf (parseSgf)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "parseSgf" $ for_ cases test

--- a/exercises/practice/sieve/stack.yaml
+++ b/exercises/practice/sieve/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/sieve/stack.yaml
+++ b/exercises/practice/sieve/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/sieve/stack.yaml
+++ b/exercises/practice/sieve/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/sieve/test/Tests.hs
+++ b/exercises/practice/sieve/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Sieve (primesUpTo)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "primesUpTo" $ for_ cases test

--- a/exercises/practice/simple-cipher/stack.yaml
+++ b/exercises/practice/simple-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/simple-cipher/stack.yaml
+++ b/exercises/practice/simple-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/simple-cipher/stack.yaml
+++ b/exercises/practice/simple-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/simple-cipher/test/Tests.hs
+++ b/exercises/practice/simple-cipher/test/Tests.hs
@@ -1,10 +1,10 @@
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Cipher (caesarDecode, caesarEncode, caesarEncodeRandom)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/simple-linked-list/stack.yaml
+++ b/exercises/practice/simple-linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/simple-linked-list/stack.yaml
+++ b/exercises/practice/simple-linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/simple-linked-list/stack.yaml
+++ b/exercises/practice/simple-linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/simple-linked-list/test/Tests.hs
+++ b/exercises/practice/simple-linked-list/test/Tests.hs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 import Test.Hspec                (Spec, it, shouldBe)
-import Test.Hspec.Runner         (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner         (configFailFast, defaultConfig, hspecWith)
 import Test.QuickCheck           (property)
 import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
 
@@ -26,7 +26,7 @@ nthDatum xs 0 = datum xs
 nthDatum xs n = nthDatum (next xs) (pred n)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/space-age/stack.yaml
+++ b/exercises/practice/space-age/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/space-age/stack.yaml
+++ b/exercises/practice/space-age/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/space-age/stack.yaml
+++ b/exercises/practice/space-age/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/space-age/test/Tests.hs
+++ b/exercises/practice/space-age/test/Tests.hs
@@ -4,12 +4,12 @@
 import Data.Foldable     (for_)
 import Data.Function     (on)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import SpaceAge (Planet(..), ageOn)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "ageOn" $ for_ cases test

--- a/exercises/practice/spiral-matrix/stack.yaml
+++ b/exercises/practice/spiral-matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/spiral-matrix/stack.yaml
+++ b/exercises/practice/spiral-matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/spiral-matrix/stack.yaml
+++ b/exercises/practice/spiral-matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/spiral-matrix/test/Tests.hs
+++ b/exercises/practice/spiral-matrix/test/Tests.hs
@@ -3,10 +3,10 @@
 import Spiral (spiral)
 
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "spiral" $ do

--- a/exercises/practice/strain/stack.yaml
+++ b/exercises/practice/strain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/strain/stack.yaml
+++ b/exercises/practice/strain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/strain/stack.yaml
+++ b/exercises/practice/strain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/strain/test/Tests.hs
+++ b/exercises/practice/strain/test/Tests.hs
@@ -1,12 +1,12 @@
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Data.List (isPrefixOf)
 
 import Strain (discard, keep)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/sublist/stack.yaml
+++ b/exercises/practice/sublist/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/sublist/stack.yaml
+++ b/exercises/practice/sublist/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/sublist/stack.yaml
+++ b/exercises/practice/sublist/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/sublist/test/Tests.hs
+++ b/exercises/practice/sublist/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Sublist (sublist)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/sum-of-multiples/stack.yaml
+++ b/exercises/practice/sum-of-multiples/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/sum-of-multiples/stack.yaml
+++ b/exercises/practice/sum-of-multiples/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/sum-of-multiples/stack.yaml
+++ b/exercises/practice/sum-of-multiples/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/sum-of-multiples/test/Tests.hs
+++ b/exercises/practice/sum-of-multiples/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import SumOfMultiples (sumOfMultiples)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "sumOfMultiples" $ for_ cases test

--- a/exercises/practice/transpose/stack.yaml
+++ b/exercises/practice/transpose/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/transpose/stack.yaml
+++ b/exercises/practice/transpose/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/transpose/stack.yaml
+++ b/exercises/practice/transpose/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/transpose/test/Tests.hs
+++ b/exercises/practice/transpose/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Transpose (transpose)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "transpose" $ for_ cases test

--- a/exercises/practice/triangle/.meta/examples/success-standard/src/Triangle.hs
+++ b/exercises/practice/triangle/.meta/examples/success-standard/src/Triangle.hs
@@ -12,6 +12,7 @@ triangleType :: (Num a, Ord a) => a -> a -> a -> TriangleType
 triangleType a b c
   | any (<=0) [a, b, c] || s1 + s2 <= s3 = Illegal
   | otherwise = [Equilateral, Isosceles, Scalene] !! pred uniqueSides
-  where sortedSides  = sort [a, b, c]
-        [s1, s2, s3] = sortedSides
-        uniqueSides  = S.size (S.fromAscList sortedSides)
+  where (s1, s2, s3) = case sort [a, b, c] of
+                         [s1', s2', s3'] -> (s1', s2', s3')
+                         _ -> error "unreachable"
+        uniqueSides  = S.size (S.fromAscList [s1, s2, s3])

--- a/exercises/practice/triangle/stack.yaml
+++ b/exercises/practice/triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/triangle/stack.yaml
+++ b/exercises/practice/triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/triangle/stack.yaml
+++ b/exercises/practice/triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/triangle/test/Tests.hs
+++ b/exercises/practice/triangle/test/Tests.hs
@@ -2,7 +2,7 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Triangle
   ( TriangleType ( Equilateral
@@ -14,7 +14,7 @@ import Triangle
   )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "triangleType" $ for_ cases test

--- a/exercises/practice/trinary/stack.yaml
+++ b/exercises/practice/trinary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/trinary/stack.yaml
+++ b/exercises/practice/trinary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/trinary/stack.yaml
+++ b/exercises/practice/trinary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/trinary/test/Tests.hs
+++ b/exercises/practice/trinary/test/Tests.hs
@@ -1,6 +1,6 @@
 import Data.Char         (intToDigit)
 import Test.Hspec        (Spec, it)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Test.QuickCheck   (Positive(Positive), (==>), property)
 
 import qualified Numeric as Num (showIntAtBase)
@@ -8,7 +8,7 @@ import qualified Numeric as Num (showIntAtBase)
 import Trinary (readTri, showTri)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do

--- a/exercises/practice/twelve-days/stack.yaml
+++ b/exercises/practice/twelve-days/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/twelve-days/stack.yaml
+++ b/exercises/practice/twelve-days/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/twelve-days/stack.yaml
+++ b/exercises/practice/twelve-days/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/twelve-days/test/Tests.hs
+++ b/exercises/practice/twelve-days/test/Tests.hs
@@ -2,13 +2,13 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 import Data.String       (fromString)
 
 import TwelveDays (recite)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "responseFor" $ for_ cases test

--- a/exercises/practice/word-count/stack.yaml
+++ b/exercises/practice/word-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/word-count/stack.yaml
+++ b/exercises/practice/word-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/word-count/stack.yaml
+++ b/exercises/practice/word-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/word-count/test/Tests.hs
+++ b/exercises/practice/word-count/test/Tests.hs
@@ -6,12 +6,12 @@ import Data.Char         (toLower)
 import Data.Foldable     (for_)
 import GHC.Exts          (fromList, toList)
 import Test.Hspec        (Spec, describe, it, shouldMatchList)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import WordCount (wordCount)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "wordCount" $ for_ cases test

--- a/exercises/practice/wordy/stack.yaml
+++ b/exercises/practice/wordy/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/wordy/stack.yaml
+++ b/exercises/practice/wordy/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/wordy/stack.yaml
+++ b/exercises/practice/wordy/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/wordy/test/Tests.hs
+++ b/exercises/practice/wordy/test/Tests.hs
@@ -3,12 +3,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import WordProblem (answer)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "answer" $ for_ cases test

--- a/exercises/practice/yacht/stack.yaml
+++ b/exercises/practice/yacht/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/yacht/stack.yaml
+++ b/exercises/practice/yacht/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/yacht/stack.yaml
+++ b/exercises/practice/yacht/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/yacht/test/Tests.hs
+++ b/exercises/practice/yacht/test/Tests.hs
@@ -2,12 +2,12 @@
 
 import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Yacht (yacht, Category(..))
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = describe "yacht" $ for_ cases test

--- a/exercises/practice/zebra-puzzle/stack.yaml
+++ b/exercises/practice/zebra-puzzle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/zebra-puzzle/stack.yaml
+++ b/exercises/practice/zebra-puzzle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/zebra-puzzle/stack.yaml
+++ b/exercises/practice/zebra-puzzle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/zebra-puzzle/test/Tests.hs
+++ b/exercises/practice/zebra-puzzle/test/Tests.hs
@@ -1,10 +1,10 @@
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import ZebraPuzzle (Resident(..), Solution(..), solve)
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = it "solve" $ solve `shouldBe` Solution { waterDrinker = Norwegian

--- a/exercises/practice/zipper/stack.yaml
+++ b/exercises/practice/zipper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.11
+resolver: lts-20.18

--- a/exercises/practice/zipper/stack.yaml
+++ b/exercises/practice/zipper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.13
+resolver: lts-20.11

--- a/exercises/practice/zipper/stack.yaml
+++ b/exercises/practice/zipper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.27
+resolver: lts-20.13

--- a/exercises/practice/zipper/test/Tests.hs
+++ b/exercises/practice/zipper/test/Tests.hs
@@ -1,6 +1,6 @@
 import Data.Maybe        (fromJust)
 import Test.Hspec        (Spec, it, shouldBe)
-import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+import Test.Hspec.Runner (configFailFast, defaultConfig, hspecWith)
 
 import Zipper
  ( BinTree(BT)
@@ -16,7 +16,7 @@ import Zipper
  )
 
 main :: IO ()
-main = hspecWith defaultConfig {configFastFail = True} specs
+main = hspecWith defaultConfig {configFailFast = True} specs
 
 specs :: Spec
 specs = do


### PR DESCRIPTION
Hi, this is my first pull request, so please point me to the relevant resources if I did something wrong :D
I wanted to run the tests locally and ran into this ghc on m1 issue: https://gitlab.haskell.org/ghc/ghc/-/issues/20592
and then into this one https://github.com/exercism/haskell/issues/1058

So what I did is basically one-liners similar to what is described in latter issue:

`grep -rl 'resolver' | xargs sed -i '' -e 's/19.27/20.13/g'`
`grep -rl 'configFastFail' | xargs sed -i '' -e 's/configFastFail/configFailFast/g'`

I ran `stack test` in some of the exercise projects and it seems to be fixed for me now.

Also one question that I have: Does the configFastFail change count as a change to the tests as described in the README, so that I should increment the serial number of the version in each exercise?