### PR TITLE
Consistency & correctness fix: `Boolean` -> `Bool`

### DIFF
--- a/exercises/concept/pacman-rules/.docs/hints.md
+++ b/exercises/concept/pacman-rules/.docs/hints.md
@@ -7,20 +7,20 @@
 
 ## 1. Define if pac-man can eat a ghost
 
-- The function must return a `Boolean` value.
+- The function must return a `Bool` value.
 - You can use the boolean operator `&&` to combine the arguments for a result.
 
 ## 2. Define if pac-man scores
 
-- The function must return a `Boolean` value.
+- The function must return a `Bool` value.
 - You can use the boolean operator `||` to combine the arguments for a result.
 
 ## 3. Define if pac-man loses
 
-- The function must return a `Boolean` value.
+- The function must return a `Bool` value.
 - You can use the boolean operators `&&` and `not` to combine the arguments for a result.
 
 ## 4. Define if pac-man wins
 
-- The function must return a `Boolean` value.
+- The function must return a `Bool` value.
 - You can use the boolean operators `&&` and `not` to combine the arguments and the result of one of the previously implemented functions.

--- a/exercises/concept/pacman-rules/.docs/instructions.md
+++ b/exercises/concept/pacman-rules/.docs/instructions.md
@@ -8,7 +8,7 @@ You have four rules to translate, all related to the game states.
 
 ## 1. Define if Pac-Man eats a ghost
 
-Define the `eatsGhost` function that takes two arguments (_whether Pac-Man has a power pellet active_ and _Pac-Man is touching a ghost_) and returns a `Boolean` value when Pac-Man is able to eat the ghost.
+Define the `eatsGhost` function that takes two arguments (_whether Pac-Man has a power pellet active_ and _Pac-Man is touching a ghost_) and returns a `Bool` value when Pac-Man is able to eat the ghost.
 The function should return `True` only when Pac-Man has a power pellet active and is touching a ghost.
 
 ```Haskell
@@ -18,7 +18,7 @@ eatsGhost False True
 
 ## 2. Define if Pac-Man scores
 
-Define the `scores` function that takes two arguments (_whether Pac-Man is touching a power pellet_ and _Pac-Man is touching a dot_) and returns a `Boolean` value if Pac-Man scored.
+Define the `scores` function that takes two arguments (_whether Pac-Man is touching a power pellet_ and _Pac-Man is touching a dot_) and returns a `Bool` value if Pac-Man scored.
 The function should return `True` when Pac-Man is touching a power pellet or a dot.
 
 ```Haskell
@@ -28,7 +28,7 @@ scores True True
 
 ## 3. Define if Pac-Man loses
 
-Define the `loses` function that takes two arguments (_whether Pac-Man has a power pellet active_ and _Pac-Man is touching a ghost_) and returns a `Boolean` value if Pac-Man loses.
+Define the `loses` function that takes two arguments (_whether Pac-Man has a power pellet active_ and _Pac-Man is touching a ghost_) and returns a `Bool` value if Pac-Man loses.
 The function should return `True` when Pac-Man is touching a ghost and does not have a power pellet active.
 
 ```Haskell
@@ -38,7 +38,7 @@ loses False True
 
 ## 4. Define if Pac-Man wins
 
-Define the `wins` function that takes three arguments (_whether Pac-Man has eaten all of the dots_, _Pac-Man has a power pellet active_, and _Pac-Man is touching a ghost_) and returns a `Boolean` value if Pac-Man wins.
+Define the `wins` function that takes three arguments (_whether Pac-Man has eaten all of the dots_, _Pac-Man has a power pellet active_, and _Pac-Man is touching a ghost_) and returns a `Bool` value if Pac-Man wins.
 The function should return `True` when Pac-Man has eaten all of the dots _and_ has not lost based on the arguments defined in part 3.
 
 ```Haskell

--- a/exercises/practice/leap/.approaches/conditional-expression/content.md
+++ b/exercises/practice/leap/.approaches/conditional-expression/content.md
@@ -56,9 +56,9 @@ Once we know if the year is a multiple of 100, we know which further test to per
 
 - need an expression that
 - chooses between exactly two options
-- depending on a single `Boolean`.
+- depending on a single `Bool`.
 
-When you have something other than a `Boolean`, use `case` instead.
+When you have something other than a `Bool`, use `case` instead.
 
 When you do not strictly need an expression, an alternative is to [use guards][guards].
 


### PR DESCRIPTION
The repo in a few places mentioned the nonexistent `Boolean` type. This commit replaces all these mentions with `Bool`.

I considered _`Bool`ean_ in some cases, but decided against it.