### PR TITLE
Fix Inconsistency Between Hints and Test Cases in Robot Simulator

### DIFF
--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -6,9 +6,7 @@ and implement the following functions:
 - `bearing`
 - `coordinates`
 - `mkRobot`
-- `simulate`
-- `turnLeft`
-- `turnRight`
+- `move`
 
 You will find a dummy data declaration and type signatures already in place,
 but it is up to you to define the functions and create a meaningful data type,


### PR DESCRIPTION
I've noticed a discrepancy between the hints provided and the actual required functions in the [Robot Simulator](https://exercism.org/tracks/haskell/exercises/robot-simulator) exercise. The hints suggest that the following functions are necessary:

- `bearing`
- `coordinates`
- `mkRobot`
- `simulate`
- `turnLeft`
- `turnRight`

However, upon reviewing the test cases, it seems that the actual required functions are:

- `bearing`
- `coordinates`
- `mkRobot`
- `move`

This mismatch might cause confusion for users trying to solve the problem. Therefore, I've made the necessary adjustments to align the hints with the test cases. 