### PR TITLE
Fix: Moved tests section to bottom of package.yaml to avoid issues with test-runner code injection

### DIFF
--- a/exercises/practice/parallel-letter-frequency/package.yaml
+++ b/exercises/practice/parallel-letter-frequency/package.yaml
@@ -14,14 +14,6 @@ library:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
 
-tests:
-  test:
-    main: Tests.hs
-    source-dirs: test
-    dependencies:
-      - parallel-letter-frequency
-      - hspec
-
 benchmarks:
   bench:
     ghc-options: -threaded -with-rtsopts=-N -O2
@@ -31,3 +23,11 @@ benchmarks:
     dependencies:
       - parallel-letter-frequency
       - criterion
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - parallel-letter-frequency
+      - hspec


### PR DESCRIPTION
The new test runner (https://github.com/exercism/haskell-test-runner/pull/104) expects the `tests` section of `package.yaml` to be the last one and the `dependencies` list to be the bottom as it simply appends new dependencies to the bottom of the file using code injection.

This change ensures that this exercise will work correctly with the latest changes of the test runner.