### PR TITLE
Fix false positives in checks for letters and punctuation

### DIFF
--- a/exercises/practice/phone-number/test/Tests.hs
+++ b/exercises/practice/phone-number/test/Tests.hs
@@ -70,11 +70,11 @@ cases =
            , expected    = Nothing
            }
     , Case { description = "invalid with letters"
-           , input       = "123-abc-7890"
+           , input       = "223-2bc-7d90"
            , expected    = Nothing
            }
-    , Case { description = "invalid with punctuations"
-           , input       = "123-@:!-7890"
+    , Case { description = "invalid with punctuation"
+           , input       = "223-5:!-7@90"
            , expected    = Nothing
            }
     , Case { description = "invalid if area code starts with 0"


### PR DESCRIPTION
The test cases "invalid with letters" and "invalid with punctuations" have area codes which begin with '1', which could cause the code under test to reject the number (instead of rejecting it for having letters or symbols). I've changed the tests to be more specific in triggering the case of a phone number containing letters or symbols.

For example, [this community solution](https://exercism.org/tracks/haskell/exercises/phone-number/solutions/frederickjeanguerin) should fail these two tests