### PR TITLE
resistor-color-trio: sync

### DIFF
--- a/exercises/practice/resistor-color-trio/.docs/instructions.md
+++ b/exercises/practice/resistor-color-trio/.docs/instructions.md
@@ -12,18 +12,18 @@ For this exercise, you need to know only three things about them:
   The program will take 3 colors as input, and outputs the correct value, in ohms.
   The color bands are encoded as follows:
 
-- Black: 0
-- Brown: 1
-- Red: 2
-- Orange: 3
-- Yellow: 4
-- Green: 5
-- Blue: 6
-- Violet: 7
-- Grey: 8
-- White: 9
+- black: 0
+- brown: 1
+- red: 2
+- orange: 3
+- yellow: 4
+- green: 5
+- blue: 6
+- violet: 7
+- grey: 8
+- white: 9
 
-In `resistor-color duo` you decoded the first two colors.
+In Resistor Color Duo you decoded the first two colors.
 For instance: orange-orange got the main value `33`.
 The third color stands for how many zeros need to be added to the main value.
 The main value plus the zeros gives us a value in ohms.


### PR DESCRIPTION
Sync the `resistor-color-trio` exercise with the latest data, as defined in https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-trio.

- Feel free to close this PR if there is another PR that also syncs this exercise.
- When approved, feel free to merge this PR yourselves (you don't have to wait for me).

As this PR only updates docs and/or metadata, it won't trigger a re-run of existing solutions (see [the docs](https://exercism.org/docs/building/tracks)).