### PR TITLE
Updated link to new site. Not sure that it is the same content.

### DIFF
--- a/exercises/practice/bob/.docs/instructions.append.md
+++ b/exercises/practice/bob/.docs/instructions.append.md
@@ -20,7 +20,7 @@ efficient handling of textual data, the `Text` type can be used.
 
 As an optional extension to this exercise, you can
 
-- Read about [string types](https://haskell-lang.org/tutorial/string-types) in Haskell.
+- Read about [string types](https://tech.fpcomplete.com/haskell/tutorial/string-types/) in Haskell.
 - Add `- text` to your list of dependencies in package.yaml.
 - Import `Data.Text` in [the following way](https://hackernoon.com/4-steps-to-a-better-imports-list-in-haskell-43a3d868273c):
 


### PR DESCRIPTION
Hi,

while doing the Bob exercise, I came across this broken link. As it turns out the original site was shutdown https://www.snoyman.com/blog/2019/02/shutting-down-haskell-lang/ and the content moved. The content is also being reworked/edited, so maybe it doesn't cover the original purpose anymore.