### PR TITLE
Update resolver lts-20.18 -> lts-24.19

### DIFF
--- a/exercises/concept/guessing-game/stack.yaml
+++ b/exercises/concept/guessing-game/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/concept/lucians-luscious-lasagna/stack.yaml
+++ b/exercises/concept/lucians-luscious-lasagna/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/concept/pacman-rules/stack.yaml
+++ b/exercises/concept/pacman-rules/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/concept/temperature/stack.yaml
+++ b/exercises/concept/temperature/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/concept/valentines-day/stack.yaml
+++ b/exercises/concept/valentines-day/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/accumulate/stack.yaml
+++ b/exercises/practice/accumulate/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/acronym/stack.yaml
+++ b/exercises/practice/acronym/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/affine-cipher/stack.yaml
+++ b/exercises/practice/affine-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/all-your-base/stack.yaml
+++ b/exercises/practice/all-your-base/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/allergies/stack.yaml
+++ b/exercises/practice/allergies/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/alphametics/stack.yaml
+++ b/exercises/practice/alphametics/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/anagram/stack.yaml
+++ b/exercises/practice/anagram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/armstrong-numbers/stack.yaml
+++ b/exercises/practice/armstrong-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/atbash-cipher/stack.yaml
+++ b/exercises/practice/atbash-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/bank-account/stack.yaml
+++ b/exercises/practice/bank-account/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/beer-song/stack.yaml
+++ b/exercises/practice/beer-song/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/binary-search-tree/stack.yaml
+++ b/exercises/practice/binary-search-tree/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/binary-search/stack.yaml
+++ b/exercises/practice/binary-search/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/binary/stack.yaml
+++ b/exercises/practice/binary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/bob/stack.yaml
+++ b/exercises/practice/bob/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/book-store/stack.yaml
+++ b/exercises/practice/book-store/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/bowling/stack.yaml
+++ b/exercises/practice/bowling/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/change/stack.yaml
+++ b/exercises/practice/change/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/clock/stack.yaml
+++ b/exercises/practice/clock/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/collatz-conjecture/stack.yaml
+++ b/exercises/practice/collatz-conjecture/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/complex-numbers/stack.yaml
+++ b/exercises/practice/complex-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/connect/stack.yaml
+++ b/exercises/practice/connect/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/crypto-square/stack.yaml
+++ b/exercises/practice/crypto-square/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/custom-set/stack.yaml
+++ b/exercises/practice/custom-set/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/darts/stack.yaml
+++ b/exercises/practice/darts/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/diamond/stack.yaml
+++ b/exercises/practice/diamond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/difference-of-squares/stack.yaml
+++ b/exercises/practice/difference-of-squares/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/dnd-character/stack.yaml
+++ b/exercises/practice/dnd-character/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/dominoes/stack.yaml
+++ b/exercises/practice/dominoes/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/etl/stack.yaml
+++ b/exercises/practice/etl/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/food-chain/stack.yaml
+++ b/exercises/practice/food-chain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/forth/stack.yaml
+++ b/exercises/practice/forth/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/game-of-life/stack.yaml
+++ b/exercises/practice/game-of-life/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/gigasecond/stack.yaml
+++ b/exercises/practice/gigasecond/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/go-counting/stack.yaml
+++ b/exercises/practice/go-counting/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/grade-school/stack.yaml
+++ b/exercises/practice/grade-school/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/grains/stack.yaml
+++ b/exercises/practice/grains/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/hamming/stack.yaml
+++ b/exercises/practice/hamming/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/hello-world/stack.yaml
+++ b/exercises/practice/hello-world/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/hexadecimal/stack.yaml
+++ b/exercises/practice/hexadecimal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/house/stack.yaml
+++ b/exercises/practice/house/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/isbn-verifier/stack.yaml
+++ b/exercises/practice/isbn-verifier/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/isogram/stack.yaml
+++ b/exercises/practice/isogram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/kindergarten-garden/stack.yaml
+++ b/exercises/practice/kindergarten-garden/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/knapsack/stack.yaml
+++ b/exercises/practice/knapsack/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/largest-series-product/stack.yaml
+++ b/exercises/practice/largest-series-product/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/leap/stack.yaml
+++ b/exercises/practice/leap/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/lens-person/stack.yaml
+++ b/exercises/practice/lens-person/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/linked-list/stack.yaml
+++ b/exercises/practice/linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/list-ops/stack.yaml
+++ b/exercises/practice/list-ops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/luhn/stack.yaml
+++ b/exercises/practice/luhn/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/matching-brackets/stack.yaml
+++ b/exercises/practice/matching-brackets/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/matrix/stack.yaml
+++ b/exercises/practice/matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/meetup/stack.yaml
+++ b/exercises/practice/meetup/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/minesweeper/stack.yaml
+++ b/exercises/practice/minesweeper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/nth-prime/stack.yaml
+++ b/exercises/practice/nth-prime/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/nucleotide-count/stack.yaml
+++ b/exercises/practice/nucleotide-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/ocr-numbers/stack.yaml
+++ b/exercises/practice/ocr-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/octal/stack.yaml
+++ b/exercises/practice/octal/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/palindrome-products/stack.yaml
+++ b/exercises/practice/palindrome-products/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/pangram/stack.yaml
+++ b/exercises/practice/pangram/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/parallel-letter-frequency/stack.yaml
+++ b/exercises/practice/parallel-letter-frequency/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/pascals-triangle/stack.yaml
+++ b/exercises/practice/pascals-triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/perfect-numbers/stack.yaml
+++ b/exercises/practice/perfect-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/phone-number/stack.yaml
+++ b/exercises/practice/phone-number/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/pig-latin/stack.yaml
+++ b/exercises/practice/pig-latin/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/poker/stack.yaml
+++ b/exercises/practice/poker/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/pov/stack.yaml
+++ b/exercises/practice/pov/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/prime-factors/stack.yaml
+++ b/exercises/practice/prime-factors/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/protein-translation/stack.yaml
+++ b/exercises/practice/protein-translation/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/proverb/stack.yaml
+++ b/exercises/practice/proverb/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/pythagorean-triplet/stack.yaml
+++ b/exercises/practice/pythagorean-triplet/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/queen-attack/stack.yaml
+++ b/exercises/practice/queen-attack/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/rail-fence-cipher/stack.yaml
+++ b/exercises/practice/rail-fence-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/raindrops/stack.yaml
+++ b/exercises/practice/raindrops/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/rational-numbers/stack.yaml
+++ b/exercises/practice/rational-numbers/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/resistor-color-duo/stack.yaml
+++ b/exercises/practice/resistor-color-duo/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/resistor-color-trio/stack.yaml
+++ b/exercises/practice/resistor-color-trio/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/reverse-string/stack.yaml
+++ b/exercises/practice/reverse-string/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/rna-transcription/stack.yaml
+++ b/exercises/practice/rna-transcription/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/robot-name/stack.yaml
+++ b/exercises/practice/robot-name/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/robot-simulator/stack.yaml
+++ b/exercises/practice/robot-simulator/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/roman-numerals/stack.yaml
+++ b/exercises/practice/roman-numerals/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/rotational-cipher/stack.yaml
+++ b/exercises/practice/rotational-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/run-length-encoding/stack.yaml
+++ b/exercises/practice/run-length-encoding/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/saddle-points/stack.yaml
+++ b/exercises/practice/saddle-points/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/satellite/stack.yaml
+++ b/exercises/practice/satellite/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/say/stack.yaml
+++ b/exercises/practice/say/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/scrabble-score/stack.yaml
+++ b/exercises/practice/scrabble-score/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/secret-handshake/stack.yaml
+++ b/exercises/practice/secret-handshake/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/series/stack.yaml
+++ b/exercises/practice/series/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/sgf-parsing/stack.yaml
+++ b/exercises/practice/sgf-parsing/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/sieve/stack.yaml
+++ b/exercises/practice/sieve/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/simple-cipher/stack.yaml
+++ b/exercises/practice/simple-cipher/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/simple-linked-list/stack.yaml
+++ b/exercises/practice/simple-linked-list/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/space-age/stack.yaml
+++ b/exercises/practice/space-age/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/spiral-matrix/stack.yaml
+++ b/exercises/practice/spiral-matrix/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/state-of-tic-tac-toe/stack.yaml
+++ b/exercises/practice/state-of-tic-tac-toe/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/strain/stack.yaml
+++ b/exercises/practice/strain/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/sublist/stack.yaml
+++ b/exercises/practice/sublist/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/sum-of-multiples/stack.yaml
+++ b/exercises/practice/sum-of-multiples/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/transpose/stack.yaml
+++ b/exercises/practice/transpose/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/triangle/stack.yaml
+++ b/exercises/practice/triangle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/trinary/stack.yaml
+++ b/exercises/practice/trinary/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/twelve-days/stack.yaml
+++ b/exercises/practice/twelve-days/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/two-bucket/stack.yaml
+++ b/exercises/practice/two-bucket/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/word-count/stack.yaml
+++ b/exercises/practice/word-count/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/word-search/stack.yaml
+++ b/exercises/practice/word-search/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/wordy/stack.yaml
+++ b/exercises/practice/wordy/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/yacht/stack.yaml
+++ b/exercises/practice/yacht/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/zebra-puzzle/stack.yaml
+++ b/exercises/practice/zebra-puzzle/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19

--- a/exercises/practice/zipper/stack.yaml
+++ b/exercises/practice/zipper/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.19


### PR DESCRIPTION
It seems that you can't build `clock` on FreeBSD. [See discussion in the forums](https://forum.exercism.org/t/cant-run-tests-for-hello-world/19870).

This PR updates the Stack snapshot from `lts-20.18` (GHC 9.2.7) to `lts-24.19` (GHC 9.10.3). I know that GHC 9.10.3 is a quite modern version, but it has reached the point release `3` so it should hopefully be quite stable. GHCup still recommends 9.6.7, but from what I understand from some discussions they will update those in the not so distant future. And based on the commit history it doesn't look like we update the stack version so often, so if we are going to be stuck on the same version for the coming two years I would prefer the most recent stable version.

I changed the resolver with the command `grep -rl 'resolver' | xargs sed -i '' -e 's/20.18/24.19/g'`