### PR TITLE
[list-ops] Make `foldl'` call unambiguous.

### DIFF
--- a/exercises/practice/list-ops/.meta/examples/success-standard/src/ListOps.hs
+++ b/exercises/practice/list-ops/.meta/examples/success-standard/src/ListOps.hs
@@ -4,13 +4,13 @@ module ListOps
   , map
   , filter
   , foldr
-  , ListOps.foldl'
+  , foldl'
   , (++)
   , concat
   ) where
 
 import Prelude hiding
-  ( length, reverse, map, filter, foldr, (++), concat )
+  ( length, reverse, map, filter, foldl', foldr, (++), concat )
 
 foldl' :: (b -> a -> b) -> b -> [a] -> b
 foldl' f = go
@@ -26,10 +26,10 @@ foldr f x0 = go
     go (x : xs) = x `f` go xs
 
 length :: [a] -> Int
-length = ListOps.foldl' (\acc _ -> 1 + acc) 0
+length = foldl' (\acc _ -> 1 + acc) 0
 
 reverse :: [a] -> [a]
-reverse = ListOps.foldl' (flip (:)) []
+reverse = foldl' (flip (:)) []
 
 map :: (a -> b) -> [a] -> [b]
 map f = foldr (\x acc -> f x : acc) []

--- a/exercises/practice/list-ops/.meta/examples/success-standard/src/ListOps.hs
+++ b/exercises/practice/list-ops/.meta/examples/success-standard/src/ListOps.hs
@@ -4,7 +4,7 @@ module ListOps
   , map
   , filter
   , foldr
-  , foldl'
+  , ListOps.foldl'
   , (++)
   , concat
   ) where
@@ -26,10 +26,10 @@ foldr f x0 = go
     go (x : xs) = x `f` go xs
 
 length :: [a] -> Int
-length = foldl' (\acc _ -> 1 + acc) 0
+length = ListOps.foldl' (\acc _ -> 1 + acc) 0
 
 reverse :: [a] -> [a]
-reverse = foldl' (flip (:)) []
+reverse = ListOps.foldl' (flip (:)) []
 
 map :: (a -> b) -> [a] -> [b]
 map f = foldr (\x acc -> f x : acc) []

--- a/exercises/practice/list-ops/src/ListOps.hs
+++ b/exercises/practice/list-ops/src/ListOps.hs
@@ -10,7 +10,7 @@ module ListOps
   ) where
 
 import Prelude hiding
-  ( length, reverse, map, filter, foldr, (++), concat )
+  ( length, reverse, map, filter, foldl', foldr, (++), concat )
 
 foldl' :: (b -> a -> b) -> b -> [a] -> b
 foldl' f z xs = error "You need to implement this function."

--- a/exercises/practice/list-ops/test/Tests.hs
+++ b/exercises/practice/list-ops/test/Tests.hs
@@ -66,20 +66,20 @@ specs = do
 
     describe "foldl'" $ do
       it "of empty list" $
-        foldl' (+) (0 :: Int) [] `shouldBe` 0
+        ListOps.foldl' (+) (0 :: Int) [] `shouldBe` 0
       it "of non-empty list" $
-        foldl' (+) (-3) [1 .. 4 :: Int] `shouldBe` 7
+        ListOps.foldl' (+) (-3) [1 .. 4 :: Int] `shouldBe` 7
       -- Track-specific test
       it "of huge list" $
-        foldl' (+) 0 [1 .. big] `shouldBe` big * (big + 1) `div` 2
+        ListOps.foldl' (+) 0 [1 .. big] `shouldBe` big * (big + 1) `div` 2
       it "with non-commutative function" $
-        foldl' (-) 10 [1 .. 4 :: Int] `shouldBe` 0
+        ListOps.foldl' (-) 10 [1 .. 4 :: Int] `shouldBe` 0
       -- Track-specific test
       it "is not just foldr . flip" $
-        foldl' (flip (:)) [] "asdf" `shouldBe` "fdsa"
+        ListOps.foldl' (flip (:)) [] "asdf" `shouldBe` "fdsa"
       -- Track-specific test
       it "is accumulator-strict (use seq or BangPatterns)" $
-        evaluate (foldl' (const id) () [throw StrictException, ()])
+        evaluate (ListOps.foldl' (const id) () [throw StrictException, ()])
         `shouldThrow` (== StrictException)
 
     describe "foldr" $ do

--- a/exercises/practice/list-ops/test/Tests.hs
+++ b/exercises/practice/list-ops/test/Tests.hs
@@ -8,6 +8,7 @@ import Prelude hiding
     ( (++)
     , concat
     , filter
+    , foldl'
     , foldr
     , length
     , map
@@ -66,20 +67,20 @@ specs = do
 
     describe "foldl'" $ do
       it "of empty list" $
-        ListOps.foldl' (+) (0 :: Int) [] `shouldBe` 0
+        foldl' (+) (0 :: Int) [] `shouldBe` 0
       it "of non-empty list" $
-        ListOps.foldl' (+) (-3) [1 .. 4 :: Int] `shouldBe` 7
+        foldl' (+) (-3) [1 .. 4 :: Int] `shouldBe` 7
       -- Track-specific test
       it "of huge list" $
-        ListOps.foldl' (+) 0 [1 .. big] `shouldBe` big * (big + 1) `div` 2
+        foldl' (+) 0 [1 .. big] `shouldBe` big * (big + 1) `div` 2
       it "with non-commutative function" $
-        ListOps.foldl' (-) 10 [1 .. 4 :: Int] `shouldBe` 0
+        foldl' (-) 10 [1 .. 4 :: Int] `shouldBe` 0
       -- Track-specific test
       it "is not just foldr . flip" $
-        ListOps.foldl' (flip (:)) [] "asdf" `shouldBe` "fdsa"
+        foldl' (flip (:)) [] "asdf" `shouldBe` "fdsa"
       -- Track-specific test
       it "is accumulator-strict (use seq or BangPatterns)" $
-        evaluate (ListOps.foldl' (const id) () [throw StrictException, ()])
+        evaluate (foldl' (const id) () [throw StrictException, ()])
         `shouldThrow` (== StrictException)
 
     describe "foldr" $ do


### PR DESCRIPTION
```
/solution/test/Tests.hs:80:9: error: [GHC-87543]
    Ambiguous occurrence ‘foldl'’.
    It could refer to
       either ‘Prelude.foldl'’,
              imported from ‘Prelude’ at test/Tests.hs:(8,1)-(16,5)
              (and originally defined in ‘ghc-internal-9.1003.0:GHC.Internal.Data.Foldable’),
           or ‘ListOps.foldl'’,
              imported from ‘ListOps’ at test/Tests.hs:22:7-12.
   |
80 |         foldl' (flip (:)) [] "asdf" `shouldBe` "fdsa"
   |         ^^^^^^
```