### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/acronym/.docs/instructions.append.md
+++ b/exercises/practice/acronym/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise works with textual data. For historical reasons, Haskell's
 `String` type is synonymous with `[Char]`, a list of characters. For more

--- a/exercises/practice/affine-cipher/.docs/instructions.append.md
+++ b/exercises/practice/affine-cipher/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 You need to implement the `decode` and `encode` functions, which decode and encode a `String` using an Affine cipher.
 You can use the provided signature if you are unsure about the types, but don't let it restrict your creativity.

--- a/exercises/practice/allergies/.docs/instructions.append.md
+++ b/exercises/practice/allergies/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise you need to to create the data type `Allergen`,
 with `Eq` and `Show` instances, and implement the following functions:

--- a/exercises/practice/alphametics/.docs/instructions.append.md
+++ b/exercises/practice/alphametics/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 You can solve this exercise with a brute force algorithm, but this will possibly have a poor runtime performance.
 Try to find a more sophisticated solution. Hint: You could try the column-wise addition algorithm that is usually taught in high school.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise you need to implement the function `anagramsFor`,
 that takes a *word* and a group of *words*, returning the ones that are

--- a/exercises/practice/atbash-cipher/.docs/instructions.append.md
+++ b/exercises/practice/atbash-cipher/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 You need to implement the `decode` and `encode` functions, which decode and encode a `String` using an Atbash cipher.
 You can use the provided signature if you are unsure about the types, but don't let it restrict your creativity.

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise you need to implement the following functions:
 

--- a/exercises/practice/beer-song/.docs/instructions.append.md
+++ b/exercises/practice/beer-song/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise is about [code refactoring](https://en.wikipedia.org/wiki/Refactoring),
 so we are providing you with a solution that already passes the tests.

--- a/exercises/practice/binary-search-tree/.docs/instructions.append.md
+++ b/exercises/practice/binary-search-tree/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise you need to create the data type `BST`,
 with `Eq` and `Show` instances, and implement the functions:

--- a/exercises/practice/binary-search/.docs/instructions.append.md
+++ b/exercises/practice/binary-search/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 Haskell has support for many types of arrays. This exercise uses immutable,
 boxed, non-strict arrays from `Data.Array`. You can read more about the use of

--- a/exercises/practice/bob/.docs/instructions.append.md
+++ b/exercises/practice/bob/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 You need to implement the `responseFor` function that returns Bob's response
 for a given input. You can use the provided signature if you are unsure

--- a/exercises/practice/book-store/.docs/instructions.append.md
+++ b/exercises/practice/book-store/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For the sake of simplicity the prices are given as integer amounts in cents. 

--- a/exercises/practice/bowling/.docs/instructions.append.md
+++ b/exercises/practice/bowling/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise you need to implement the function `score`,
 that takes a sequence of bowling *rolls* and returns the final score or

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 It's a 24 hour clock going from "00:00" to "23:59".
 

--- a/exercises/practice/custom-set/.docs/instructions.append.md
+++ b/exercises/practice/custom-set/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to create the data type `CustomSet`,
 with `Eq` and `Show` instances, and implement the following functions:

--- a/exercises/practice/diamond/.docs/instructions.append.md
+++ b/exercises/practice/diamond/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 You need to implement the `diamond` function which prints a diamond starting at
 `A` with the given character at its widest points. You can use the provided

--- a/exercises/practice/dnd-character/.docs/instructions.append.md
+++ b/exercises/practice/dnd-character/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise uses QuickCheck generators. Here are some resources to get started:
 

--- a/exercises/practice/etl/.docs/instructions.append.md
+++ b/exercises/practice/etl/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise works with textual data. For historical reasons, Haskell's
 `String` type is synonymous with `[Char]`, a list of characters. For more

--- a/exercises/practice/food-chain/.docs/instructions.append.md
+++ b/exercises/practice/food-chain/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise is about [code refactoring](https://en.wikipedia.org/wiki/Refactoring),
 so we are providing you with a solution that already passes the tests.

--- a/exercises/practice/forth/.docs/instructions.append.md
+++ b/exercises/practice/forth/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to create the data type `ForthState`
 and implement the following functions:

--- a/exercises/practice/go-counting/.docs/instructions.append.md
+++ b/exercises/practice/go-counting/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to implement the following functions:
 

--- a/exercises/practice/grade-school/.docs/instructions.append.md
+++ b/exercises/practice/grade-school/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise you need to create the data type `School`
 and implement the following functions:

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to define the constant `hello`.
 

--- a/exercises/practice/house/.docs/instructions.append.md
+++ b/exercises/practice/house/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise is about [code refactoring](https://en.wikipedia.org/wiki/Refactoring),
 so we are providing you with a solution that already passes the tests.

--- a/exercises/practice/isogram/.docs/instructions.append.md
+++ b/exercises/practice/isogram/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise works with textual data. For historical reasons, Haskell's
 `String` type is synonymous with `[Char]`, a list of characters. For more

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise you need to implement the function `isLeapYear`
 that takes a year and determines whether it is a leap year.

--- a/exercises/practice/linked-list/.docs/instructions.append.md
+++ b/exercises/practice/linked-list/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to create the data type `Deque`
 and implement the following functions:

--- a/exercises/practice/matrix/.docs/instructions.append.md
+++ b/exercises/practice/matrix/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to create the data type `Matrix`,
 with `Eq` and `Show` instances, and implement the following functions:

--- a/exercises/practice/meetup/.docs/instructions.append.md
+++ b/exercises/practice/meetup/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to implement the `meetupDay` function.
 

--- a/exercises/practice/octal/.docs/instructions.append.md
+++ b/exercises/practice/octal/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For the appropriate amount of challenge here, you should only
 use functionality present in Prelude. Try not to use Data.List,

--- a/exercises/practice/palindrome-products/.docs/instructions.append.md
+++ b/exercises/practice/palindrome-products/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To solve this exercise you need to implement these two functions:
 

--- a/exercises/practice/pig-latin/.docs/instructions.append.md
+++ b/exercises/practice/pig-latin/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 The unit tests provide examples of words. Try and cluster consonants
 independent of the specific combinations of consonants in the unit tests.

--- a/exercises/practice/queen-attack/.docs/instructions.append.md
+++ b/exercises/practice/queen-attack/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to implement the following functions:
 

--- a/exercises/practice/raindrops/.docs/instructions.append.md
+++ b/exercises/practice/raindrops/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 You need to implement the `convert` function that returns number converted to
 raindrop sound. You can use the provided signature if you are unsure

--- a/exercises/practice/resistor-color-duo/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color-duo/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 You need to implement the function
 

--- a/exercises/practice/resistor-color-trio/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color-trio/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 You need to implement the functions `label` and `ohms`. You can use the
 provided signature for `label`, but don't let it restrict your creativity.

--- a/exercises/practice/rna-transcription/.docs/instructions.append.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Given invalid output, your program should return the first invalid character.

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to create the data type `Robot`,
 as a mutable variable, and the data type `RunState`. You also need to

--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to create the data type `Robot`,
 and implement the following functions:

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise you need to implement the function `numerals`,
 that *maybe* converts a number to a *string* representing a roman numeral.

--- a/exercises/practice/rotational-cipher/.docs/instructions.append.md
+++ b/exercises/practice/rotational-cipher/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 You need to implement the `rotate` function, which takes an `Int` and a `String`, and then encodes it using an rotational cipher.
 You can use the provided signature if you are unsure about the types, but don't let it restrict your creativity.

--- a/exercises/practice/series/.docs/instructions.append.md
+++ b/exercises/practice/series/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise you need to implement the function `slices`,
 that takes a *text* and returns the subsequences of digits with a

--- a/exercises/practice/sgf-parsing/.docs/instructions.append.md
+++ b/exercises/practice/sgf-parsing/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 The Sgf module should export a parseSgf module with the following signature:
 

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to create the data type `LinkedList`,
 and implement the following functions:

--- a/exercises/practice/space-age/.docs/instructions.append.md
+++ b/exercises/practice/space-age/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 In this exercise, we provided the definition of the
 [algebraic data type](https://learnyouahaskell.github.io/making-our-own-types-and-typeclasses)

--- a/exercises/practice/sublist/.docs/instructions.append.md
+++ b/exercises/practice/sublist/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 The type
 [`Ordering`](https://hackage.haskell.org/package/base/docs/Data-Ord.html#t:Ordering)

--- a/exercises/practice/trinary/.docs/instructions.append.md
+++ b/exercises/practice/trinary/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For the appropriate amount of challenge here, you should only
 use functionality present in Prelude. Try not to use Data.List,

--- a/exercises/practice/twelve-days/.docs/instructions.append.md
+++ b/exercises/practice/twelve-days/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 You need to implement the `recite` function which outputs the lyrics to
 'The Twelve Days of Christmas'. You can use the provided signature

--- a/exercises/practice/two-bucket/.docs/instructions.append.md
+++ b/exercises/practice/two-bucket/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Note
+# Instructions append
+
+## Note
 
 For the sake of simplicity you can assume that the starting bucket to be filled first
 is always bucket one - it is enough just to swap the buckets if it shall be bucket two.

--- a/exercises/practice/word-count/.docs/instructions.append.md
+++ b/exercises/practice/word-count/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise you need to implement the function `wordCount`,
 that takes a *text* and returns how many times each *word* appears.

--- a/exercises/practice/wordy/.docs/instructions.append.md
+++ b/exercises/practice/wordy/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This is a perfect opportunity to learn some Attoparsec or Parsec!


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.