### PR TITLE
verify-exercises-in-docker: avoid cleanup failure

### DIFF
--- a/bin/verify-exercises-in-docker
+++ b/bin/verify-exercises-in-docker
@@ -42,6 +42,7 @@ run_tests() {
         --rm \
         --network none \
         --mount type=bind,src="${PWD}",dst=/solution \
+        --mount type=volume,dst=/solution/.stack-work \
         --mount type=bind,src="${PWD}",dst=/output \
         --mount type=tmpfs,dst=/tmp \
         "${image}" "${slug}" /solution /output


### PR DESCRIPTION
Docker runs the test runner as root. 

Previously in a directory like `/tmp/exercism-verify-*-#####/` we were creating a root-owned subdirectory `.stack-work/` that the script failed to cleanup. Now that subdirectory is no longer being created under `/tmp/exercism-verify-bob-#####/`  and cleanup succeeds.
